### PR TITLE
fix typo: height

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
 var panel = require("sdk/panel").Panel({
   contentURL: "./default.html",
   width: 300,
-  heigth: 250,
+  height: 250,
   position: {
     bottom: 10,
     left: 10


### PR DESCRIPTION
Unrelated: Not sure how tied we are to FF 38.x support, but if we want to jump on the ES6 template string bandwagon we could possibly micro optimize some of the string concat stuff.