### PR TITLE
Disable panel autohide

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ var panel = require("sdk/panel").Panel({
   }
 });
 
+var { getActiveView } = require("sdk/view/core");
+getActiveView(panel).setAttribute("noautohide", true);
+
 var cm = require("sdk/context-menu");
 
 cm.Item({


### PR DESCRIPTION
Fixes #1.

@meandavejustice mind taking a look? this solves the problem of the panel autohiding itself, but introduces the problem that you can't get rid of the panel. :-)

The fix is to call panel.hide(), I'm just not yet sure how we can add a button to the panel / style the panel.