### PR TITLE
Fixes #27 Doesn't work on youtube.com/watch pages

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,20 @@ cm.Item({
   }
 });
 
+cm.Item({
+  label: "Send to mini player",
+  context: [
+  cm.URLContext(['*.youtube.com']),
+  cm.SelectorContext('[class*="yt-uix-sessionlink"]'),
+  ],
+  contentScript: "self.on('click', function (node, data) {" +
+                 "  self.postMessage(node.href);" +
+                 "});",
+  onMessage: function(url) {
+    updatePanel(constructYoutubeEmbedUrl(url));
+  }  
+});
+
 function updatePanel(url) {
   panel.port.emit('set-video', url);
   panel.show();


### PR DESCRIPTION
Within cm.SelectorContext, this uses "class*=" instead of "href*=" to trigger the context menu on YouTube.com main pages and channel pages.

For some reason, using "href*=/watch?v" wasn't working.