### PR TITLE
Rename getYoutubeUrl to getYouTubeUrl

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
  */
 
 const getVideoId = require('get-video-id');
-const getYoutubeUrl = require('./lib/get-youtube-url.js');
+const getYouTubeUrl = require('./lib/get-youtube-url.js');
 const getVimeoUrl = require('./lib/get-vimeo-url.js');
 
 var panel = require('sdk/panel').Panel({
@@ -75,7 +75,7 @@ cm.Item({
   onMessage: function(url) {
     const id = getVideoId(url);
     updatePanel({domain: 'youtube.com', id: id, src: ''});
-    getYoutubeUrl(id, function(err, streamUrl) {
+    getYouTubeUrl(id, function(err, streamUrl) {
       if (!err) updatePanel({src: streamUrl});
     });
   }
@@ -93,7 +93,7 @@ cm.Item({
   onMessage: function(url) {
     const id = getVideoId(url);
     updatePanel({domain: 'youtube.com', id: id, src: ''});
-    getYoutubeUrl(id, function(err, streamUrl) {
+    getYouTubeUrl(id, function(err, streamUrl) {
       if (!err) updatePanel({src: streamUrl});
     });
   }

--- a/lib/get-youtube-url.js
+++ b/lib/get-youtube-url.js
@@ -3,9 +3,9 @@ var qs = require('sdk/querystring');
 
 const baseURL = 'http://www.youtube.com/get_video_info';
 
-module.exports = getYoutubeUrl;
+module.exports = getYouTubeUrl;
 
-function getYoutubeUrl(videoId, cb) {
+function getYouTubeUrl(videoId, cb) {
   Request({
     url: baseURL + '?' + qs.stringify({video_id: videoId}),
     onComplete: function (resp) {


### PR DESCRIPTION
Silly little nit, but it's "YouTube", not "Youtube" (per their footer/trademark).

r? @meandavejustice 