### PR TITLE
Tooltips for controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,7 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
-
-// uncomment for manual testing purposes
-// const testSrc = 'https://r17---sn-ab5l6n7r.googlevideo.com/videoplayback?mv=m&mt=1468352728&ms=au&id=o-AE03DODlnfLGm9N8CcnmyLtuxZePWALwIV9O1-aQoA-H&expire=1468374597&mime=video%2Fmp4&ip=65.88.88.176&requiressl=yes&pl=23&mn=sn-ab5l6n7r&mm=31&source=youtube&lmt=1439378563427365&cnr=14&sparams=cnr%2Cdur%2Cid%2Cinitcwndbps%2Cip%2Cipbits%2Citag%2Clmt%2Cmime%2Cmm%2Cmn%2Cms%2Cmv%2Cnh%2Cpl%2Cratebypass%2Crequiressl%2Csource%2Cupn%2Cexpire&nh=IgpwcjA1LmxnYTA3KgkxMjcuMC4wLjE&sver=3&initcwndbps=1900000&signature=961892B3A4873E80CBE75F9FE5B872D2E2A8060C.7A76E7058BC532B524B2C24C06BE30C72BA527EA&dur=154.807&itag=22&fexp=9416126%2C9416891%2C9419452%2C9422596%2C9425078%2C9428398%2C9431012%2C9431452%2C9431677%2C9431838%2C9433096%2C9433380%2C9433946%2C9435036%2C9435526%2C9435876%2C9437066%2C9437553%2C9437742%2C9438280%2C9438361%2C9438661%2C9438662%2C9438734%2C9439652%2C9439965%2C9440047%2C9440302%2C9440376%2C9440542%2C9440850&key=yt6&upn=SA-YwegWsYw&ratebypass=yes&ipbits=0';
-// const vtestSrc = 'https://08-lvl3-pdl.vimeocdn.com/01/3108/0/15540231/29736282.mp4?expires=1468015395&token=0623f1dfc4b0c96f737a2';
+const ReactTooltip = require('react-tooltip');
+const cn = require('classnames');
 
 const defaultData = {
   id: '',
@@ -27,31 +25,6 @@ window.AppData = new Proxy(defaultData, {
     return true;
   }
 });
-
-// uncomment for manual testing purposes
-// setTimeout(function() {
-//   window.AppData = Object.assign(window.AppData, {
-//     loaded: false,
-//     error: false,
-//     progress: 0.001,
-//     playing: false,
-//     volume: '0.5',
-//     src: testSrc,
-//     domain: 'youtube.com'
-//   });
-// }, 2000);
-
-// setTimeout(function() {
-//   window.AppData = Object.assign(window.AppData, {
-//     loaded: false,
-//     error: false,
-//     progress: 0,
-//     playing: false,
-//     volume: '0.5',
-//     src: vtestSrc,
-//     domain: 'vimeo.com'
-//   });
-// }, 8000);
 
 function formatTime(seconds) {
   const now = new Date(seconds * 1000);
@@ -105,7 +78,11 @@ const LoadingView = React.createClass({
   render: function() {
     return (
         <div className={'loading'} onMouseEnter={this.enterView} onMouseLeave={this.leaveView}>
-          <a onClick={this.close} className={'close ' + this.state.hovered ? '': 'hidden'} />
+          <ReactTooltip place='bottom' effect='solid' />
+
+          <a className={cn('close', {hidden: this.state.hovered})}
+             onClick={this.close} data-tip='Close' />
+
           <img src={'img/loading-bars.svg'}
                alt={'loading animation'}
                width={64} height={64}></img>
@@ -220,34 +197,45 @@ const PlayerView = React.createClass({
   },
   render: function() {
     return (
-      <div onMouseEnter={this.enterPlayer} onMouseLeave={this.leavePlayer} className={'video-wrapper'}>
-        <div className={'controls ' + (this.state.hovered ? '' : 'hidden ') + (this.props.minimized ? 'minimized' : '')}
-             onMouseEnter={this.enterControls} onMouseLeave={this.leaveControls}>
-          <div className={'left'}>
-            <a onClick={this.play} className={this.props.playing ? 'play hidden' : 'play'} />
-            <a onClick={this.pause} className={this.props.playing ? 'pause' : 'pause hidden'} />
-            <a onClick={this.mute} className={!this.props.muted ? 'mute' : 'mute hidden'} />
-            <a onClick={this.unmute} className={this.props.muted ? 'unmute' : 'unmute hidden'} />
-            <input type={'range'} className={this.state.showVolume ? 'volume' : 'volume hidden'}
-                   min={'0'} max={'1'} step={'.01'} value={this.props.volume} onChange={this.setVolume}/>
+        <div className={'video-wrapper'} onMouseEnter={this.enterPlayer}
+             onMouseLeave={this.leavePlayer}>
+          <div className={cn('controls', {hidden: !this.state.hovered, minimized: this.props.minimized})}
+               onMouseEnter={this.enterControls} onMouseLeave={this.leaveControls}>
+            <div className='left'>
+              <ReactTooltip place='bottom' effect='solid' />
+
+              <a onClick={this.play} data-tip='Play'
+                 className={cn('play', {hidden: this.props.playing})} />
+              <a onClick={this.pause} data-tip='Pause'
+                 className={cn('pause', {hidden: !this.props.playing})} />
+              <a onClick={this.mute} data-tip='Mute'
+                 className={cn('mute', {hidden: this.props.muted})} />
+              <a onClick={this.unmute} data-tip='Unmute'
+                 className={cn('unmute', {hidden: !this.props.muted})} />
+              <input type='range' className={cn('volume', {hidden: !this.state.showVolume})}
+                     min='0' max='1' step='.01' value={this.props.volume}
+                     onChange={this.setVolume}/>
+            </div>
+
+            <div className='right'>
+              <a onClick={this.sendToTab} data-tip='Send to tab' className='tab' />
+              <a onClick={this.minimize} data-tip='Minimize'
+                 className={cn('minimize', {hidden: this.props.minimized})} />
+              <a onClick={this.maximize} data-tip='Maximize'
+                 className={cn('maximize', {hidden: !this.props.minimized})} />
+              <a onClick={this.close} data-tip='Close' className='close' />
+            </div>
+         </div>
+
+          <div className={cn('progress', {hidden: !this.state.hovered || this.props.minimized})}>
+            <span className={'domain'}>{this.props.domain}</span>
+            <div className={'time'}>{this.props.currentTime}</div>
+            <progress className={'video-progress'} onClick={this.setTime}
+                      value={this.props.progress + ''}  />
           </div>
 
-          <div className={'right'}>
-            <a onClick={this.sendToTab} className={'tab'} />
-            <a onClick={this.minimize} className={!this.props.minimized ? 'minimize' : 'minimize hidden'} />
-            <a onClick={this.maximize} className={this.props.minimized ? 'maximize' : 'maximize hidden'} />
-            <a onClick={this.close} className={'close'} />
-          </div>
+          <video id={'video'} ref={'video'} src={this.props.src} autoplay={false} />
         </div>
-
-        <div className={'progress ' + ((this.state.hovered && !this.props.minimized) ? '' : 'hidden')}>
-          <span className={'domain'}>{this.props.domain}</span>
-          <div className={'time'}>{this.props.currentTime}</div>
-          <progress className={'video-progress'} value={this.props.progress + ''} onClick={this.setTime} />
-        </div>
-
-        <video id={'video'} ref={'video'} src={this.props.src} autoplay={false} />
-      </div>
     );
   }
 });

--- a/data/panel.css
+++ b/data/panel.css
@@ -92,12 +92,8 @@ body {
 
 .controls.minimized {
     background: #000 !important;
-    display: block !important;
+    display: flex !important;
     opacity: .9;
-}
-
-.controls.minimized a {
-    margin-top: 10px;
 }
 
 .left,

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "get-video-id": "1.0.0"
+    "get-video-id": "1.0.0",
+    "classnames": "2.2.5",
+    "react-tooltip": "3.0.13"
   },
   "devDependencies": {
     "addons-linter": "0.14.1",


### PR DESCRIPTION
- added tooltips to all controls in min-vid
- added react-tooltip dependency
- fresh build of addon
- fixes #66 

post-review:
* reworked ReactTooltip to use `data-tip` to simplify code as @pdehaan suggested
* added `classnames` dep for simplifying `hidden` class logic, thanks @pdehaan 
* fixed issue where pause tooltip was displaying as "play"
* fixed weird minimized control panel css issue
* filed https://github.com/meandavejustice/min-vid/issues/110 for issue with tooltip placement when minimized
* fixed issue of tooltips being cut off by window when maximized