### PR TITLE
Add ESLint 'no-var' and 'prefer-const' rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,4 +25,6 @@ rules:
   eqeqeq: 2
   indent: [2, 2]
   no-unused-vars: [2, {vars: all, args: none}]
+  no-var: 1
+  prefer-const: 2
   quotes: [2, single, {avoidEscape: true, allowTemplateLiterals: true}]

--- a/data/resize-listener.js
+++ b/data/resize-listener.js
@@ -1,19 +1,19 @@
 function debounce(func, wait, immediate) {
-  var timeout;
+  let timeout;
   return function() {
-    var context = this, args = arguments;
-    var later = function() {
+    const context = this, args = arguments;
+    const later = function() {
       timeout = null;
       if (!immediate) func.apply(context, args);
     };
-    var callNow = immediate && !timeout;
+    const callNow = immediate && !timeout;
     clearTimeout(timeout);
     timeout = setTimeout(later, wait);
     if (callNow) func.apply(context, args);
   };
 }
 
-var onResize = debounce(function() {
+const onResize = debounce(function() {
   self.port.emit('resized', {});
 }, 50);
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const getVideoId = require('get-video-id');
 const getYouTubeUrl = require('./lib/get-youtube-url.js');
 const getVimeoUrl = require('./lib/get-vimeo-url.js');
 
-var panel = require('sdk/panel').Panel({
+const panel = require('sdk/panel').Panel({
   contentURL: './default.html',
   contentScriptFile: './controls.js',
   width: 320,
@@ -23,7 +23,7 @@ const { getActiveView } = require('sdk/view/core');
 getActiveView(panel).setAttribute('noautohide', true);
 
 panel.port.on('message', opts => {
-  var title = opts.action;
+  const title = opts.action;
 
   if (title === 'send-to-tab') {
     const pageUrl = getPageUrl(opts.domain, opts.id);
@@ -120,7 +120,7 @@ function updatePanel(opts) {
   panel.show();
 }
 
-var pageMod = require('sdk/page-mod');
+const pageMod = require('sdk/page-mod');
 
 pageMod.PageMod({
   include: '*',

--- a/lib/get-vimeo-url.js
+++ b/lib/get-vimeo-url.js
@@ -1,4 +1,4 @@
-var Request = require('sdk/request').Request;
+const Request = require('sdk/request').Request;
 
 module.exports = getVimeoUrl;
 

--- a/lib/get-youtube-url.js
+++ b/lib/get-youtube-url.js
@@ -1,5 +1,5 @@
-var Request = require('sdk/request').Request;
-var qs = require('sdk/querystring');
+const Request = require('sdk/request').Request;
+const qs = require('sdk/querystring');
 
 const baseURL = 'http://www.youtube.com/get_video_info';
 
@@ -9,7 +9,7 @@ function getYouTubeUrl(videoId, cb) {
   Request({
     url: baseURL + '?' + qs.stringify({video_id: videoId}),
     onComplete: function (resp) {
-      var streamParams = qs.parse(resp.text)['url_encoded_fmt_stream_map'].split(',')[0];
+      const streamParams = qs.parse(resp.text)['url_encoded_fmt_stream_map'].split(',')[0];
       cb(null, qs.parse(streamParams).url);
     }
   }).get();


### PR DESCRIPTION
Current status (downgraded to warnings, so Travis-CI still passes):

```sh
$ npm run lint

> min-vid@0.1.0 lint /Users/pdehaan/dev/github/mozilla/min-vid
> eslint .


/Users/pdehaan/dev/github/mozilla/min-vid/data/resize-listener.js
   2:3  warning  Unexpected var, use let or const instead  no-var
   4:5  warning  Unexpected var, use let or const instead  no-var
   5:5  warning  Unexpected var, use let or const instead  no-var
   9:5  warning  Unexpected var, use let or const instead  no-var
  16:1  warning  Unexpected var, use let or const instead  no-var

/Users/pdehaan/dev/github/mozilla/min-vid/index.js
   11:1  warning  Unexpected var, use let or const instead  no-var
   26:3  warning  Unexpected var, use let or const instead  no-var
  123:1  warning  Unexpected var, use let or const instead  no-var

/Users/pdehaan/dev/github/mozilla/min-vid/lib/get-vimeo-url.js
  1:1  warning  Unexpected var, use let or const instead  no-var

/Users/pdehaan/dev/github/mozilla/min-vid/lib/get-youtube-url.js
   1:1  warning  Unexpected var, use let or const instead  no-var
   2:1  warning  Unexpected var, use let or const instead  no-var
  12:7  warning  Unexpected var, use let or const instead  no-var

✖ 12 problems (0 errors, 12 warnings)
```
