### PR TITLE
Switch to embed player for youtube videos

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,7 +7,7 @@ const defaultData = {
   src: '',
   domain: '',
   minimized: false,
-  loaded: true,
+  loaded: false,
   error: false,
   muted: false,
   currentTime: '0:00 / 0:00',
@@ -30,5 +30,3 @@ function renderApp() {
   ReactDOM.render(React.createElement(AppView, window.AppData),
                   document.getElementById('container'));
 }
-
-renderApp();

--- a/client-lib/send-to-addon.js
+++ b/client-lib/send-to-addon.js
@@ -1,5 +1,5 @@
 module.exports = sendToAddon;
 
 function sendToAddon(obj) {
-  window.dispatchEvent(new CustomEvent('message', {detail: obj}));
+  window.dispatchEvent(new CustomEvent('addon-message', {detail: obj}));
 }

--- a/client-lib/yt-ctrl.js
+++ b/client-lib/yt-ctrl.js
@@ -1,0 +1,60 @@
+module.exports = {
+  init: init,
+  play: play,
+  pause: pause,
+  mute: mute,
+  unmute: unmute,
+  setVolume: setVolume,
+  getVolume: getVolume,
+  getTime: getTime,
+  setTime: setTime,
+  getDuration: getDuration,
+};
+
+function init(id, opts) {
+  if (!window.YT) return opts.onError('window.YT not yet initialized');
+
+  window.YTPlayer = new window.YT.Player(id, {
+    events: {
+      onReady: opts.onReady,
+      onError: opts.onError
+    }
+  });
+}
+
+function play() {
+  window.YTPlayer.playVideo();
+}
+
+function pause() {
+  window.YTPlayer.pauseVideo();
+}
+
+function mute() {
+  window.YTPlayer.mute();
+}
+
+function unmute() {
+  window.YTPlayer.unMute();
+}
+
+// v:int
+function setVolume(v) {
+  window.YTPlayer.setVolume(v);
+}
+
+function getVolume() {
+  return window.YTPlayer.getVolume();
+}
+
+function getTime() {
+  return window.YTPlayer.getCurrentTime();
+}
+
+function setTime(seconds) {
+  window.YTPlayer.seekTo(seconds, true);
+}
+
+function getDuration() {
+  return window.YTPlayer.getDuration();
+}

--- a/components/app-view.js
+++ b/components/app-view.js
@@ -18,22 +18,25 @@ module.exports = React.createClass({
       position: {
         bottom: 0,
         left: 0
-      }
+      },
+      dragging: false
     };
   },
   handleDragStart: function(ev) {
     if (ev.target.classList.contains('controls') || ev.target.id === 'video') {
       sendToAddon(xtend(this.state, {action: 'expand-panel'}));
-      this.setState({draggablePosition: null});
+      this.setState({draggablePosition: null, dragging: true});
     } else return;
   },
   handleDragStop: function(ev, data) {
-    this.setState({position: {
-      left: data.x,
-      top: data.y
-    }});
-    sendToAddon(xtend(this.state, {action: 'shrink-panel'}));
-    this.setState({draggablePosition: {x: 0, y: 0}});
+    if (this.state.dragging) {
+      this.setState({position: {
+        left: data.x,
+        top: data.y
+      }});
+      sendToAddon(xtend(this.state, {action: 'shrink-panel'}));
+      this.setState({draggablePosition: {x: 0, y: 0}, dragging: false});
+    } else return;
   },
   render: function() {
     return (

--- a/components/error-view.js
+++ b/components/error-view.js
@@ -1,11 +1,26 @@
 const React = require('react');
-const sendMetricsEvent = require('../client-lib/send-metrics-event.js');
+const cn = require('classnames');
+const ReactTooltip = require('react-tooltip');
+const GeneralControls = require('./general-controls.js');
 
 module.exports = React.createClass({
+  getInitialState: function() {
+    return {hovered: false};
+  },
+  enterView: function() {
+    this.setState({hovered: true});
+  },
+  leaveView: function() {
+    this.setState({hovered: false});
+  },
   render: function() {
-    sendMetricsEvent('error_view', 'render');
     return (
-        <div className={'error'}>
+        <div className={'error'} onMouseEnter={this.enterView} onMouseLeave={this.leaveView}>
+          <ReactTooltip place='bottom' effect='solid' />
+          <div className={cn('controls', {hidden: !this.state.hovered, minimized: this.props.minimized})}>
+            <div className='left' />
+            <GeneralControls {...this.props} />
+          </div>
           <img src={'img/sadface.png'}
                alt={'sadface because of error'}
                width={164} height={164}></img>

--- a/components/general-controls.js
+++ b/components/general-controls.js
@@ -1,30 +1,40 @@
 const React = require('react');
 const cn = require('classnames');
+const ytCtrl = require('../client-lib/yt-ctrl');
 const sendToAddon = require('../client-lib/send-to-addon');
 const sendMetricsEvent = require('../client-lib/send-metrics-event.js');
 
 module.exports = React.createClass({
+  getView: function() {
+    return this.props.loaded ? 'player_view' : 'loading_view';
+  },
   close: function() {
-    sendMetricsEvent('loading_view', 'close');
+    sendMetricsEvent(this.getView(), 'close');
     sendToAddon({action: 'close'});
   },
   minimize: function() {
-    sendMetricsEvent('loading_view', 'minimize');
+    sendMetricsEvent(this.getView(), 'minimize');
     sendToAddon({action: 'minimize'});
     window.AppData.minimized = true;
   },
   maximize: function() {
-    sendMetricsEvent('loading_view', 'maximize');
+    sendMetricsEvent(this.getView(), 'maximize');
     sendToAddon({action: 'maximize'});
     window.AppData.minimized = false;
   },
   sendToTab: function() {
-    sendMetricsEvent('loading_view', 'send_to_tab');
+    sendMetricsEvent(this.getView(), 'send_to_tab');
+    let currentTime = 0;
+
+    if (this.getView() === 'player_view') {
+      currentTime = this.props.isYt ? ytCtrl.getTime() : this.refs.video.currentTime;
+    }
+
     sendToAddon({
       action: 'send-to-tab',
-      id: window.AppData.id,
-      domain: window.AppData.domain,
-      time: this.refs.video.currentTime
+      id: this.props.id,
+      domain: this.props.domain,
+      time: currentTime
     });
   },
   render: function() {
@@ -35,8 +45,8 @@ module.exports = React.createClass({
           onClick={this.minimize} data-tip='Minimize' />
         <a onClick={this.maximize} data-tip='Maximize'
           className={cn('maximize', {hidden: !this.props.minimized})} />
-        <a className='close' onClick={this.close} data-tip='Close' /> 
+        <a className='close' onClick={this.close} data-tip='Close' />
       </div>
-    );  
+    );
   }
 });

--- a/components/loading-view.js
+++ b/components/loading-view.js
@@ -1,7 +1,6 @@
 const React = require('react');
 const cn = require('classnames');
 const ReactTooltip = require('react-tooltip');
-const sendMetricsEvent = require('../client-lib/send-metrics-event.js');
 const GeneralControls = require('./general-controls.js');
 
 module.exports = React.createClass({
@@ -15,13 +14,12 @@ module.exports = React.createClass({
     this.setState({hovered: false});
   },
   render: function() {
-    sendMetricsEvent('loading_view', 'render');
     return (
         <div className='loading' onMouseEnter={this.enterView} onMouseLeave={this.leaveView}>
-          <ReactTooltip place='bottom' effect='solid' />
+        <ReactTooltip place='bottom' effect='solid' />
           <div className={cn('controls', {hidden: !this.state.hovered, minimized: this.props.minimized})}>
             <div className='left' />
-            <GeneralControls props={this.props} />
+            <GeneralControls {...this.props} />
           </div>
 
           <img src={'img/loading-bars.svg'} alt={'loading animation'}

--- a/data/controls.js
+++ b/data/controls.js
@@ -18,6 +18,6 @@ self.port.on('set-video', opts => {
 // Bridge between app.js window messages to the
 // addon. We pass true for the wantsUntrusted param
 // in order to access the message events. #82
-window.addEventListener('message', function(ev) {
-  self.port.emit('message', ev.detail);
+window.addEventListener('addon-message', function(ev) {
+  self.port.emit('addon-message', ev.detail);
 }, false, true);

--- a/data/default.html
+++ b/data/default.html
@@ -20,6 +20,7 @@
   </head>
   <body>
     <div id="container"></div>
+    <script src="https://www.youtube.com/iframe_api"></script>
     <script src="bundle.js"></script>
   </body>
 </html>

--- a/data/panel.css
+++ b/data/panel.css
@@ -6,6 +6,7 @@
 
 html,
 body,
+iframe,
 video {
     border: none;
     margin: 0;
@@ -15,6 +16,7 @@ video {
 html,
 body,
 video,
+iframe,
 .player-wrap,
 .app,
 .loading,
@@ -24,6 +26,7 @@ video,
 }
 
 html,
+iframe,
 body {
     background: transparent;
     text-align: center;

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ const panel = require('sdk/panel').Panel({
 const { getActiveView } = require('sdk/view/core');
 getActiveView(panel).setAttribute('noautohide', true);
 
-panel.port.on('message', opts => {
+panel.port.on('addon-message', opts => {
   const title = opts.action;
 
   if (title === 'send-to-tab') {

--- a/lib/get-youtube-url.js
+++ b/lib/get-youtube-url.js
@@ -1,16 +1,19 @@
-const Request = require('sdk/request').Request;
-const qs = require('sdk/querystring');
-
-const baseURL = 'https://www.youtube.com/get_video_info';
+const baseURL = 'https://www.youtube.com/embed';
+const params = require('sdk/querystring').stringify({
+  autoplay: 0,
+  modestbranding: 1,
+  controls: 0,
+  disablekb: 0,
+  enablejsapi: 1,
+  fs: 0,
+  iv_load_policy: 3,
+  loop: 0,
+  rel: 0,
+  showinfo: 0
+});
 
 module.exports = getYouTubeUrl;
 
 function getYouTubeUrl(videoId, cb) {
-  Request({
-    url: baseURL + '?' + qs.stringify({video_id: videoId}),
-    onComplete: function (resp) {
-      const streamParams = qs.parse(resp.text)['url_encoded_fmt_stream_map'].split(',')[0];
-      cb(null, qs.parse(streamParams).url);
-    }
-  }).get();
+  cb(null, `${baseURL}/${videoId}/?${params}`);
 }


### PR DESCRIPTION
- fixes #150 (send-to-tab broken)
- now uses iframe embed player for youtube
- fix issue where handleDragStop was being called prematurely in `components/app-view.js`
- switched string for post-message from 'message' to 'addon-message' to avoid conflicts with
  youtube api container
- create `client-lib/yt-ctrl.js` for handling iframe interactions
- add generalControls to `components/error-view.js`
- address issue where `components/general-controls.js` was sending the wrong view name
  to metrics
- remove old call to yt api in `lib/get-youtube/url.js`