### PR TITLE
Adding multiprocess permission to ensure e10s support

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "engines": {
     "firefox": ">=38.0a1"
   },
+  "permissions": {
+    "multiprocess": true
+  },
   "bugs": {
     "url": "https://github.com/meandavejustice/min-vid/issues"
   },


### PR DESCRIPTION
- fixes #143 

attached packaged and signed xpi for testing.

[addon.zip](https://github.com/meandavejustice/min-vid/files/445963/addon.zip)
(you will need to unzip to get access to the xpi, because github doesn't support uploading xpis)
