### PR TITLE
Remove precommit 'build-script' hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "mv-xpi": "mv min-vid.xpi dist/addon.xpi",
     "postpackage": "addons-linter dist/addon.xpi -o text",
     "prepackage": "npm run lint",
+    "prepush": "npm run package",
     "dev": "npm run watch-script & npm run watch & http-server -c-1",
     "deploy": "npm run package && ./bin/sign"
   },
-  "precommit": "package",
   "license": "MPL-2.0",
   "dependencies": {
     "get-video-id": "1.0.0"
@@ -46,8 +46,8 @@
     "eslint": "3.1.1",
     "eslint-plugin-react": "5.2.2",
     "http-server": "0.9.0",
+    "husky": "0.11.7",
     "jpm": "1.1.1",
-    "pre-commit": "1.1.3",
     "react": "15.1.0",
     "react-dom": "15.1.0",
     "react-tooltip": "3.0.13",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dev": "npm run watch-script & npm run watch & http-server -c-1",
     "deploy": "npm run package && ./bin/sign"
   },
-  "precommit": "build-script, package",
+  "precommit": "package",
   "license": "MPL-2.0",
   "dependencies": {
     "get-video-id": "1.0.0"


### PR DESCRIPTION
I'm not familiar w/ the [**pre-commit**](http://npm.im/pre-commit) module, but I don't think we need to run `build-script` as a `precommit` hook, since we explicitly call that as the first step in the `npm run package` script:

```js
  "precommit": "build-script, package",
  "scripts": {
    "build-script": "browserify app.js -o data/bundle.js -t [ babelify --presets [ react ] ]",
    ...   
    "prepackage": "npm run lint",
    "package": "npm run build-script && jpm xpi && npm run mv-xpi",
    "postpackage": "addons-linter dist/addon.xpi -o text",
    ...
  },
```