### PR TITLE
Run ESLint on bin/ files

### DIFF
--- a/bin/sign
+++ b/bin/sign
@@ -12,20 +12,22 @@
  * them into the /dist directory.
  *
  */
-var fs = require('fs');
-var path = require('path');
-var request = require('request');
-var jwt = require('jsonwebtoken');
-var manifest = require('../package.json');
-var version = manifest.version;
-var apiKey = process.env['AMO_USER'];
-var apiSecret = process.env['AMO_SECRET'];
-var authToken = jwt.sign({iss: apiKey}, apiSecret, {
-  algorithm: "HS256",
+
+/* eslint-disable no-console */
+
+const fs = require('fs');
+const request = require('request');
+const jwt = require('jsonwebtoken');
+const manifest = require('../package.json');
+const version = manifest.version;
+const apiKey = process.env['AMO_USER'];
+const apiSecret = process.env['AMO_SECRET'];
+const authToken = jwt.sign({iss: apiKey}, apiSecret, {
+  algorithm: 'HS256',
   expiresIn: 60
 });
-var signedOpts = {
-  url: 'https://addons.mozilla.org/api/v3/addons/@' + manifest.name + '/versions/'+version+ '/',
+const signedOpts = {
+  url: 'https://addons.mozilla.org/api/v3/addons/@' + manifest.name + '/versions/' + version + '/',
   headers: {
     'Authorization': 'JWT ' + authToken
   }
@@ -34,10 +36,10 @@ var signedOpts = {
 request(signedOpts, signCb);
 
 function signCb(err, resp, body) {
-  if (!err && resp.statusCode == 200) {
-    var info = JSON.parse(body);
+  if (!err && resp.statusCode === 200) {
+    const info = JSON.parse(body);
     if (info.files.length) {
-      var ws = fs.createWriteStream('dist/signed-addon.xpi').on('finish', removeGeneratedXpi);
+      const ws = fs.createWriteStream('dist/signed-addon.xpi').on('finish', removeGeneratedXpi);
       signedOpts.url = info.files[0].download_url;
       request(signedOpts).pipe(ws);
     }
@@ -47,7 +49,7 @@ function signCb(err, resp, body) {
 // if we need to sign and distribute our add-on, we want to use this method
 function distAddon() {
   // sign our add-on
-  var generatedXpi = 'dist/addon.xpi';
+  const generatedXpi = 'dist/addon.xpi';
   signAddon(generatedXpi, function(err, signedXpiPath) {
     if (err) return console.error(err);
     // remove our generated xpi since we now have a signed version
@@ -62,7 +64,7 @@ function distAddon() {
 }
 
 function removeGeneratedXpi() {
-  var generatedXpi = 'dist/addon.xpi';
+  const generatedXpi = 'dist/addon.xpi';
   fs.unlink(generatedXpi, function(err) {
     if (err) console.error(err);
     else console.log('removed ' + generatedXpi + ' successfully');

--- a/bin/update-version
+++ b/bin/update-version
@@ -1,16 +1,15 @@
 #!/usr/bin/env node
 
-var fs = require('fs');
-var util = require('util');
-var childProcess = require('child_process');
+const fs = require('fs');
+const childProcess = require('child_process');
 
 // Load the current manifest.json
-var manifestFilename = __dirname + '/../package.json';
-var manifest = require(manifestFilename);
+const manifestFilename = __dirname + '/../package.json';
+const manifest = require(manifestFilename);
 
 // Come up with a version tag suffix based on CIRCLE_TAG, or fall back to
 // looking up the current git commit hash.
-var tag;
+let tag;
 if (process.env['CIRCLE_TAG']) {
   tag = 'tag-' + process.env['CIRCLE_TAG'];
 } else {
@@ -21,9 +20,9 @@ if (process.env['CIRCLE_TAG']) {
 }
 
 // Update the version tag suffix.
-var versionParts = manifest.version.split('-');
+const versionParts = manifest.version.split('-');
 manifest.version = versionParts[0] + '-' + tag;
 
 // Write the modified manifest.json
-var manifestJSON = JSON.stringify(manifest, null, '  ');
+const manifestJSON = JSON.stringify(manifest, null, '  ');
 fs.writeFileSync(manifestFilename, manifestJSON);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/meandavejustice/min-vid/issues"
   },
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint . bin/*",
     "build-script": "browserify app.js -o data/bundle.js -t [ babelify --presets [ react ] ]",
     "watch-script": "watchify app.js -o data/bundle.js -t [ babelify --presets [ react ] ]",
     "start": "npm run watch",


### PR DESCRIPTION
Noticed that the files in bin/* don't have any extensions, so therefore don't get automatically linted by ESLint.

This PR now lints everything in bin/*, and auto-fixed all the issues using ESLint's awsome `--fix` flag, via `$ npm run lint -- --fix`.
No interesting errors. Mostly just changing`const` to `let`/`var`, one `===` violation, removed a couple unused deps, and me just disabling the `no-console` rule for the CLI tools.

I don't have/need AMO creds to fully test this, so @meandavejustice may want to give it a test drive before merging to make sure I didn't Peter something up horribly.