### PR TITLE
Make border draggable

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,8 @@ const panel = require('sdk/panel').Panel({
   }
 });
 
-// check for linux here
-if (system.platform !== 'linux') {
+// Draggability seems to work for windows and mac, but not linux.
+if (system.platform === 'winnt' || system.platform === 'darwin') {
   makePanelDraggable(panel);
 }
 

--- a/lib/make-panel-draggable.js
+++ b/lib/make-panel-draggable.js
@@ -3,39 +3,26 @@ const { getActiveView } = require('sdk/view/core');
 module.exports = makePanelDraggable;
 
 // Makes an SDK panel draggable. Pass in an SDK panel.
-function makePanelDraggable(panel) {
+function makePanelDraggable(sdkPanel) {
   // Remove the panel from the XUL DOM, make some attribute changes, then
   // reattach it. Reseating in the DOM triggers updates in the XBL bindings
   // that give the panel draggability and remove some SDK styling.
-  const panelEl = getActiveView(panel);
-  const parentEl = panelEl.parentNode;
+  const panel = getActiveView(sdkPanel);
+  const parent = panel.parentNode;
 
-  parentEl.removeChild(panelEl);
+  parent.removeChild(panel);
 
-  panelEl.setAttribute('noautohide', true);
-  panelEl.setAttribute('backdrag', true);
-  panelEl.setAttribute('style', '-moz-appearance: none; border: 0; margin: 0; background: rgba(0,0,0,0)');
-  panelEl.removeAttribute('type');
+  panel.setAttribute('noautohide', true);
+  panel.setAttribute('backdrag', true);
+  panel.setAttribute('style', '-moz-appearance: none; cursor: grab; border: 0; margin: 0; padding: 24px; background: rgba(0,0,0,0);');
+  panel.removeAttribute('type');
 
-  // Next, we need a XUL document to create a drag handle. There may be better
-  // ways to obtain the document element, but this works:
-  let doc = parentEl;
-  while (doc !== null && doc.nodeType !== 9) {
-    doc = doc.parentNode;
-  }
+  // Toggling -moz-appearance shows a background area with colors that reflect
+  // the system color scheme.
+  panel.onmouseenter = () => { panel.style.MozAppearance = 'menupopup'; }
+  panel.onmouseleave = () => { panel.style.MozAppearance = 'none'; }
+  panel.onmousedown = () => { panel.style.cursor = 'grabbing'; }
+  panel.onmouseup = () => { panel.style.cursor = 'grab'; }
 
-  const dragHandle = doc.createElement('label');
-  dragHandle.id = 'backdragspot';
-  dragHandle.setAttribute('value', 'click here to drag the thing');
-  dragHandle.setAttribute('style', 'background: #2b2b2b; border: 1px solid black; color: #d5d5d5; cursor: grab');
-  dragHandle.setAttribute('hidden', true);
-  dragHandle.onmousedown = () => { dragHandle.style.cursor = 'grabbing' }
-  dragHandle.onmouseup = () => { dragHandle.style.cursor = 'grab' }
-  panelEl.appendChild(dragHandle);
-
-  // make the drag handle only visible on mouseover
-  panelEl.onmouseenter = () => { dragHandle.setAttribute('hidden', false) };
-  panelEl.onmouseleave = () => { dragHandle.setAttribute('hidden', true) };
-
-  parentEl.appendChild(panelEl);
+  parent.appendChild(panel);
 }


### PR DESCRIPTION
@meandavejustice Mind taking a look?

- Replaced drag handle with a draggable border area (technically padding) shown when the panel is hovered (including the invisible border area around the player window). Seems less janky, but still needs work.
- Replaced the "if not linux, make draggable" check with "if win or mac, make draggable", as discussed in #193.
- Refactored make-panel-draggable.js to remove the 'El' suffix on all the elements. I liked it at first, then decided it looked odd.