### PR TITLE
handle attribution_links in YouTube urls

### DIFF
--- a/lib/launch-video.js
+++ b/lib/launch-video.js
@@ -1,4 +1,5 @@
 const getVideoId = require('get-video-id');
+const qs = require('sdk/querystring');
 
 module.exports = launchVideo;
 
@@ -9,7 +10,15 @@ function launchVideo(opts, panel) {
   //       getUrlFn: getYouTubeUrl,
   //       domain: 'youtube.com',
   //       src: streamURL or ''}
-  const id = getVideoId(opts.url);
+  let id;
+
+  // TODO: submit a fix to getVideoId for this. #226
+  if (opts.url.indexOf('attribution_link')) {
+    id = getIdFromAttributionLink(opts.url);
+  } else {
+    id = getVideoId(opts.url);
+  }
+
   panel.port.emit('set-video', {domain: opts.domain, id: id, src: opts.src || ''});
   panel.show();
   if (!opts.src) {
@@ -20,4 +29,13 @@ function launchVideo(opts, panel) {
       }
     });
   }
+}
+
+function getIdFromAttributionLink(url) {
+  const matcher = 'attribution_link?';
+  const idx = url.indexOf(matcher);
+  const partialUrl = decodeURIComponent(url).substring(idx + matcher.length);
+  const idMatcher = 'watch?';
+  const idx2 = partialUrl.indexOf(idMatcher);
+  return qs.parse(partialUrl.substring(idx2 + idMatcher.length)).v;
 }


### PR DESCRIPTION
- fixes #221
- filed #226 as a follow up to upstream the fix to get-video-id