### PR TITLE
Update fix parsing of vimeo urls for send-to-tab/relaunch flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "get-video-id": "1.0.0"
+    "get-video-id": "1.0.1"
   },
   "devDependencies": {
     "addons-linter": "0.14.1",


### PR DESCRIPTION
- update get-video-id to 1.0.1
- fixes #261