### PR TITLE
Position panel relative to screen by changing 'level' attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ const panel = require('sdk/panel').Panel({
 panel.coords = { bottomOffset: -10, leftOffset: 10 };
 
 getActiveView(panel).setAttribute('noautohide', true);
+getActiveView(panel).setAttribute('level', 'top');
 
 // Draggability seems to work for windows and mac, but not linux.
 if (system.platform === 'winnt' || system.platform === 'darwin') {


### PR DESCRIPTION
@meandavejustice Hey, mind taking a look? This should be a quick one. I'm not sure you'll see any changes, since you are on an unusual window manager, but on Mac, this makes the experience much nicer. Commit message has more details:

----

This change ensures the panel doesn't move when the parent browser
window moves.

This change also sets the z-index so that the min-vid panel is shown
above all Firefox windows, and (on Mac) the panel is shown even if FF
loses application focus.

Fixes #253.