### PR TITLE
Enable min-vid to work with multiple windows

### DIFF
--- a/data/controls.js
+++ b/data/controls.js
@@ -4,6 +4,12 @@
  * http://mozilla.org/MPL/2.0/.
  */
 
+// Ping the addon when ready, and whenever the addon asks if we are ready.
+self.port.emit('worker-ready');
+self.port.on('worker-ready-check', () => {
+  self.port.emit('worker-ready');
+});
+
 self.port.on('set-video', opts => {
   opts = Object.assign(opts, {
     loaded: false,

--- a/index.js
+++ b/index.js
@@ -4,121 +4,22 @@
  * http://mozilla.org/MPL/2.0/.
  */
 
-const system = require('sdk/system');
 const pageMod = require('sdk/page-mod');
-const { getActiveView } = require('sdk/view/core');
 const getYouTubeUrl = require('./lib/get-youtube-url.js');
 const getVimeoUrl = require('./lib/get-vimeo-url.js');
 const launchVideo = require('./lib/launch-video');
 const sendMetricsData = require('./lib/send-metrics-data.js');
 const initContextMenuHandlers = require('./lib/context-menu-handlers.js');
-const makePanelDraggable = require('./lib/make-panel-draggable.js');
-const { setTimeout } = require('sdk/timers');
-
-const dimensions = {
-  width: 320,
-  height: 180,
-  minimizedHeight: 40
-};
-
-const panel = require('sdk/panel').Panel({
-  contentURL: './default.html',
-  contentScriptFile: './controls.js',
-  width: dimensions.width,
-  height: dimensions.height,
-  position: {
-    bottom: 10,
-    left: 10
-  }
-});
-
-// Init the panel's location state
-panel.coords = { bottomOffset: -10, leftOffset: 10 };
-
-getActiveView(panel).setAttribute('noautohide', true);
-getActiveView(panel).setAttribute('level', 'top');
-
-// Draggability seems to work for windows and mac, but not linux.
-if (system.platform === 'winnt' || system.platform === 'darwin') {
-  // We have to wait until XBL has initialized before changing the 'type'.
-  setTimeout(() => { makePanelDraggable(panel, dimensions); }, 5000);
-}
-
-function adjustHeight(newHeight) {
-  // Resize the panel by changing the height of the panel, iframe, and stack
-  // elements.
-  // On linux, makePanelDraggable isn't invoked, so the stack doesn't exist.
-  const xulPanel = getActiveView(panel);
-  const stack = xulPanel.getElementsByTagName('stack') && xulPanel.getElementsByTagName('stack')[0];
-  const frame = xulPanel.getElementsByTagName('iframe')[0];
-
-  frame.setAttribute('height', newHeight);
-  if (stack) stack.setAttribute('height', newHeight);
-  xulPanel.sizeTo(dimensions.width, newHeight);
-
-  redrawPanel();
-}
-
-function redrawPanel() {
-  const xulPanel = getActiveView(panel);
-
-  // travel up the DOM to get a document pointer
-  let doc = xulPanel;
-  while (doc !== null && doc.nodeType !== 9) {
-    doc = doc.parentNode;
-  }
-
-  xulPanel.moveToAnchor(doc.documentElement, 'bottomleft bottomleft', panel.coords.leftOffset, panel.coords.bottomOffset);
-}
-
-panel.port.on('addon-message', opts => {
-  const title = opts.action;
-
-  if (title === 'send-to-tab') {
-    const pageUrl = getPageUrl(opts.domain, opts.id, opts.time);
-    if (pageUrl) require('sdk/tabs').open(pageUrl);
-    else {
-      console.error('could not parse page url for ', opts); // eslint-disable-line no-console
-      panel.port.emit('set-video', {error: 'Error loading video from ' + opts.domain});
-    }
-    panel.port.emit('set-video', {domain: '', src: ''});
-    panel.hide();
-  } else if (title === 'close') {
-    panel.port.emit('set-video', {domain: '', src: ''});
-    panel.hide();
-  } else if (title === 'minimize') {
-    adjustHeight(dimensions.minimizedHeight);
-  } else if (title === 'maximize') {
-    adjustHeight(dimensions.height);
-  } else if (title === 'metrics-event') {
-    sendMetricsData(opts, panel);
-  }
-});
-
-function getPageUrl(domain, id, time) {
-  let url;
-  if (domain.indexOf('youtube') > -1) {
-    url = `https://youtube.com/watch?v=${id}&t=${Math.floor(time)}`;
-  } else if (domain.indexOf('vimeo') > -1) {
-    const min = Math.floor(time / 60);
-    const sec = Math.floor(time - min * 60);
-    url = `https://vimeo.com/${id}#t=${min}m${sec}s`;
-  } else if (domain.indexOf('vine') > -1) {
-    url = `https://vine.co/v/${id}`;
-  }
-
-  return url;
-}
+const panelUtils = require('./lib/panel-utils.js');
 
 // handle browser resizing
 pageMod.PageMod({
   include: '*',
-  contentScriptFile: './resize-listener.js',
+  contentScriptFile: './resize-listener.js?cachebust=' + Date.now(),
   onAttach: function(worker) {
     worker.port.on('resized', function() {
-      if (panel.isShowing) {
-        redrawPanel();
-      }
+      const panel = panelUtils.getPanel();
+      if (panel && panel.isShowing) panelUtils.redraw();
     });
   }
 });
@@ -126,8 +27,8 @@ pageMod.PageMod({
 // add launch icon to video embeds
 pageMod.PageMod({
   include: '*',
-  contentStyleFile: './icon-overlay.css',
-  contentScriptFile: './icon-overlay.js',
+  contentStyleFile: './icon-overlay.css?cachebust=' + Date.now(),
+  contentScriptFile: './icon-overlay.js?cachebust=' + Date.now(),
   onAttach: function(worker) {
     worker.port.on('launch', function(opts) {
       if (opts.domain.indexOf('youtube.com') > -1) {
@@ -136,24 +37,21 @@ pageMod.PageMod({
           object: 'overlay_icon',
           method: 'launch',
           domain: opts.domain
-        }, panel);
-        launchVideo(opts, panel);
+        });
+        launchVideo(opts);
       } else if (opts.domain.indexOf('vimeo.com')  > -1) {
         opts.getUrlFn = getVimeoUrl;
         sendMetricsData({
           object: 'overlay_icon',
           method: 'launch',
           domain: opts.domain
-        }, panel);
-        launchVideo(opts, panel);
+        });
+        launchVideo(opts);
       }
     });
-
-    worker.port.on('metrics', function(opts) {
-      sendMetricsData(opts);
-    });
+    worker.port.on('metrics', sendMetricsData);
   }
 });
 
 // add 'send-to-mini-player' option to context menu
-initContextMenuHandlers(panel);
+initContextMenuHandlers();

--- a/lib/context-menu-handlers.js
+++ b/lib/context-menu-handlers.js
@@ -45,19 +45,19 @@ function getSelectors(videoService, shouldEncode) {
 
 module.exports = init;
 
-function init(panel) {
+function init() {
   const onMessageVimeoHandler = (url) => {
-    sendMetricsData({changed: 'activate', domain: 'vimeo.com'}, panel);
+    sendMetricsData({changed: 'activate', domain: 'vimeo.com'});
     launchVideo({url: url,
                  domain: 'vimeo.com',
-                 getUrlFn: getVimeoUrl}, panel);
+                 getUrlFn: getVimeoUrl});
   };
 
   const onMessageYouTubeHandler = (url) => {
-    sendMetricsData({changed: 'activate', domain: 'youtube.com'}, panel);
+    sendMetricsData({changed: 'activate', domain: 'youtube.com'});
     launchVideo({url: url,
                  domain: 'youtube.com',
-                 getUrlFn: getYouTubeUrl}, panel);
+                 getUrlFn: getYouTubeUrl});
   };
 
   /*
@@ -141,10 +141,10 @@ function init(panel) {
     context: cm.SelectorContext(getSelectors('vine')),
     contentScript: contextMenuContentScript,
     onMessage: function(url) {
-      sendMetricsData({changed: 'activate', domain: 'vine.co'}, panel);
+      sendMetricsData({changed: 'activate', domain: 'vine.co'});
       launchVideo({url: url,
                    domain: 'vine.co',
-                   getUrlFn: getVineUrl}, panel);
+                   getUrlFn: getVineUrl});
     }
   });
 
@@ -159,10 +159,10 @@ function init(panel) {
     });`,
     onMessage: function(url) {
       const mp4 = url.replace(/thumbs/, 'videos').split(/\.jpg/)[0];
-      sendMetricsData({changed: 'activate', domain: 'vine.co'}, panel);
+      sendMetricsData({changed: 'activate', domain: 'vine.co'});
       launchVideo({url: url,
                    domain: 'vine.co',
-                   src: mp4}, panel);
+                   src: mp4});
     }
   });
 
@@ -191,10 +191,10 @@ function init(panel) {
         domain = 'vine.co';
       }
       if (domain && getUrlFn) {
-        sendMetricsData({changed: 'activate', domain: domain}, panel);
+        sendMetricsData({changed: 'activate', domain: domain});
         launchVideo({url: decoded,
                      domain: domain,
-                     getUrlFn: getUrlFn}, panel);
+                     getUrlFn: getUrlFn});
       }
     }
   });

--- a/lib/launch-video.js
+++ b/lib/launch-video.js
@@ -1,35 +1,44 @@
 const getVideoId = require('get-video-id');
 const qs = require('sdk/querystring');
+const panelUtils = require('./panel-utils.js');
 
 module.exports = launchVideo;
 
 // Pass in a video URL as opts.src or pass in a video URL lookup function as opts.getUrlFn
-function launchVideo(opts, panel) {
-  if (!panel) throw new Error('panel needs to be provided as second argument');
-  // opts {url: url,
-  //       getUrlFn: getYouTubeUrl,
-  //       domain: 'youtube.com',
-  //       time: 16 // integer seconds OPTIONAL
-  //       src: streamURL or ''}
-  let id;
+function launchVideo(opts) {
+  // UpdateWindow might create a new panel, so do the remaining launch work
+  // asynchronously.
+  panelUtils.updateWindow();
+  panelUtils.whenPanelReady(() => {
+    const panel = panelUtils.getPanel();
+    // opts {url: url,
+    //       getUrlFn: getYouTubeUrl,
+    //       domain: 'youtube.com',
+    //       time: 16 // integer seconds OPTIONAL
+    //       src: streamURL or ''}
+    let id;
 
-  // TODO: submit a fix to getVideoId for this. #226
-  if (opts.url.indexOf('attribution_link') > -1) {
-    id = getIdFromAttributionLink(opts.url);
-  } else {
-    id = getVideoId(opts.url);
-  }
+    // TODO: submit a fix to getVideoId for this. #226
+    if (opts.url.indexOf('attribution_link') > -1) {
+      id = getIdFromAttributionLink(opts.url);
+    } else {
+      id = getVideoId(opts.url);
+    }
 
-  panel.port.emit('set-video', {domain: opts.domain, id: id, src: opts.src || ''});
-  panel.show();
-  if (!opts.src) {
-    opts.getUrlFn(id, function(err, streamUrl) {
-      if (!err) {
+    panel.port.emit('set-video', {domain: opts.domain, id: id, src: opts.src || ''});
+    panel.show();
+    if (!opts.src) {
+      opts.getUrlFn(id, function(err, streamUrl) {
+        // Be careful not to close over the outer panel reference.
+        // If the panel went away while waiting for the stream, just give up.
+        const panel = panelUtils.getPanel();
+        if (err) return console.error('LaunchVideo failed to get the streamUrl: ', err); // eslint-disable-line no-console
+        if (!panel) return console.error('LaunchVideo lost the panel while waiting for the streamUrl.'); // eslint-disable-line no-console
         panel.port.emit('set-video', {src: streamUrl});
         panel.show();
-      }
-    }, opts.time);
-  }
+      }, opts.time);
+    }
+  });
 }
 
 function getIdFromAttributionLink(url) {

--- a/lib/make-panel-draggable.js
+++ b/lib/make-panel-draggable.js
@@ -5,10 +5,14 @@ module.exports = makePanelDraggable;
 
 // Makes an SDK panel draggable. Pass in an SDK panel and an object of the
 // form { width: 320, height: 180 }.
-function makePanelDraggable(sdkPanel, dimensions) {
+function makePanelDraggable(dimensions, sdkPanel, mouseupHandler) {
   // Remove the panel from the XUL DOM, make some attribute changes, then
   // reattach it. Reseating in the DOM triggers updates in the XBL bindings
   // that give the panel draggability and remove some SDK styling.
+
+  // Note: sdkPanel is optional, used to avoid circular refs with panel-utils.js.
+  sdkPanel = sdkPanel || require('./panel-utils.js').getPanel();
+
   const panel = getActiveView(sdkPanel);
   const frame = panel.getElementsByTagName('iframe')[0];
   const parent = panel.parentNode;
@@ -19,12 +23,7 @@ function makePanelDraggable(sdkPanel, dimensions) {
   panel.setAttribute('style', '-moz-appearance: none; border: 0; margin: 0; background: rgba(0,0,0,0)');
   panel.removeAttribute('type');
 
-  // Next, we need a XUL document to create a drag handle. There may be better
-  // ways to obtain the document element, but this works:
-  let doc = parent;
-  while (doc !== null && doc.nodeType !== 9) {
-    doc = doc.parentNode;
-  }
+  const doc = panel.ownerDocument;
 
   const dragHandle = doc.createElement('label');
   dragHandle.setAttribute('style', 'background: url("' + self.data.url('img/move-icon.svg') + '") center no-repeat; background-size: 15px 15px; cursor: grab');
@@ -32,18 +31,9 @@ function makePanelDraggable(sdkPanel, dimensions) {
   dragHandle.onmousedown = () => { dragHandle.style.cursor = 'grabbing' };
   dragHandle.onmouseup = () => {
     dragHandle.style.cursor = 'grab';
-
-    const docLeft = doc.documentElement.getBoundingClientRect().left;
-    const docBottom = doc.documentElement.getBoundingClientRect().bottom;
-    const panelLeft = panel.getBoundingClientRect().left;
-    const panelBottom = panel.getBoundingClientRect().bottom;
-
-    const bottomOffset = panelBottom - docBottom;
-    const leftOffset = panelLeft - docLeft;
-
-    // Store the offset to preserve location when window is resized.
-    sdkPanel.coords.bottomOffset = bottomOffset;
-    sdkPanel.coords.leftOffset = leftOffset;
+    // Notify panel-utils that the position has changed, without introducing a
+    // circular dependency by require()ing that file here.
+    mouseupHandler();
   };
   panel.appendChild(dragHandle);
 

--- a/lib/panel-utils.js
+++ b/lib/panel-utils.js
@@ -1,0 +1,361 @@
+/*
+ * This Source Code is subject to the terms of the Mozilla Public License
+ * version 2.0 (the 'License'). You can obtain a copy of the License at
+ * http://mozilla.org/MPL/2.0/.
+ */
+
+/* global Services */
+
+const system = require('sdk/system');
+const events = require('sdk/system/events');
+const { getActiveView } = require('sdk/view/core');
+const sendMetricsData = require('./send-metrics-data.js');
+const makePanelDraggable = require('./make-panel-draggable.js');
+const simpleStorage = require('sdk/simple-storage');
+const { setTimeout } = require('sdk/timers');
+const { Cu } = require('chrome');
+Cu.import('resource://gre/modules/Services.jsm');
+
+// panel utils:
+// getPanel(): gets a panel reference. Pass the getter inside closures,
+//             instead of the panel itself, so the panel can be freed when needed.
+// create(): creates a panel. Note that code that needs the panel to be ready
+//           should register a callback with whenPanelReady().
+// destroy(): destroys a panel.
+// whenPanelReady(): register a callback that will fire immediately, if the panel's
+//                   ready; otherwise,, it'll fire when the panel is ready.
+//                   Note that the list of callbacks is cleared when the panel is
+//                   destroyed, so you need to create() first, then call this method.
+
+
+// Note: keeping this whenPanelReady bit state sectioned off in case
+// we replace it with a Task or Promise eventually.
+const whenPanelReady = (function() {
+  let isPanelReady = false;
+  let panelReadyListeners = [];
+
+  function _whenPanelReady(cb) {
+    if (!isPanelReady) {
+      panelReadyListeners.push(cb);
+      return;
+    }
+
+    try {
+      cb();
+    } catch (ex) {
+      console.error('Panel ready listener threw when invoked: ', ex); // eslint-disable-line no-console
+    }
+  }
+
+  // When the panel is destroyed, call reset() to clear callbacks.
+  _whenPanelReady.reset = function whenPanelReady__reset() {
+    isPanelReady = false;
+    panelReadyListeners = [];
+  };
+
+  // When the panel is ready, call ready() to fire callbacks.
+  _whenPanelReady.ready = function whenPanelReady__ready() {
+    isPanelReady = true;
+    panelReadyListeners.forEach(cb => {
+      try {
+        cb();
+      } catch (ex) {
+        console.error('Panel ready listener threw when invoked: ', ex); // eslint-disable-line no-console
+      }
+    });
+    panelReadyListeners = [];
+  };
+
+  return _whenPanelReady;
+})();
+
+const DEFAULT_SCREEN_COORDS = {
+  x: 10,
+  y: 10
+};
+
+const DEFAULT_DIMENSIONS = {
+  height: 180,
+  width: 320,
+  minimizedHeight: 40
+};
+
+const DEFAULT_PANEL_OPTIONS = {
+  contentURL: './default.html?cachebust=' + Date.now(),
+  contentScriptFile: './controls.js?cachebust=' + Date.now(),
+  position: {
+    top: 10,
+    left: 10
+  }
+};
+
+let sdkPanel;
+let userDimensions;
+let userPanelOptions;
+// simple-storage is synchronous, so use a cached value whenever possible
+let screenPosition = simpleStorage.storage.screenPosition || DEFAULT_SCREEN_COORDS;
+let isUserPosition = !!simpleStorage.storage.isUserPosition;
+
+// TODO: Ensure we can abort at any point in this lengthy setup process.
+function create(dimensions, panelOptions) {
+  // Sequence of events:
+  // 1. Destroy the panel, if it exists.
+  if (sdkPanel) {
+    console.error('panel.create called, but a panel already exists. Deleting old panel.'); // eslint-disable-line no-console
+    destroy();
+  }
+
+  // 2. Register listeners to be attached after the panel is ready.
+  whenPanelReady(() => {
+    sdkPanel.port.on('addon-message', messageHandler);
+  });
+
+  // 3. Create the panel and set the userDimensions, userPanelOptions,
+  //    userScreenCoords module globals.
+  sdkPanel = _create(dimensions, panelOptions);
+
+  // 4. Once the panel is in the XUL DOM (after _checkPanel calls the cb),
+  //    modify the element's attributes and make it draggable (on Windows
+  //    or Mac). Reseat in the XUL DOM to trigger the native Panel XBL code
+  //    to run again. But note that we have to wait till DOMContentLoaded
+  //    to do all this.
+  _checkPanel(() => {
+    const xulPanel = getActiveView(sdkPanel);
+    events.on('DOMContentLoaded', onContentLoaded);
+    function onContentLoaded(data) {
+      if (data.subject !== xulPanel) return;
+      events.off('DOMContentLoaded', onContentLoaded);
+      xulPanel.setAttribute('noautohide', true);
+      xulPanel.setAttribute('level', 'top');
+
+      // Draggability seems to work for windows and mac, but not linux.
+      if (system.platform === 'winnt' || system.platform === 'darwin') {
+        makePanelDraggable(userDimensions, sdkPanel, updatePosition);
+      } else {
+        // If we don't enable dragging, we still need to reseat the element
+        // to get XBL to re-run with the other attribute changes.
+        xulPanel.parentNode.replaceChild(xulPanel, xulPanel);
+      }
+
+      // Because we just modified the underlying XBL, we need to again wait for
+      // the panel to be loaded and reinserted into the XUL DOM.
+      _checkPanel(() => {
+        // 5. Register panel load listener (panel.port.once('worker-ready', ... )).
+        //    The content scripts are loaded after the panel and iframe are fully
+        //    loaded, so when the content script sends a worker-ready ping, we know
+        //    the panel is fully initialized.
+        // TODO: if this ever throws, then we need to add a `panel.port` check to _checkPanel.
+        sdkPanel.port.once('worker-ready', () => {
+          // 6. After worker-ready, and after the draggable panel is found in the XUL
+          //    DOM, correct the position via redraw(), call the whenPanelReady callbacks,
+          //    and we're finally done.
+          redraw();
+          whenPanelReady.ready();
+        });
+
+        // Because we use a setTimeout loop to wait for the panel to appear in the
+        // XUL DOM, we might miss the worker-ready signal. So, try to ask the
+        // content script to send the worker-ready signal; if it throws, it's not
+        // ready yet, so we are fine to wait. If it was fully initialized, it'll
+        // resend the worker-ready signal, and initialization will continue.
+        try {
+          sdkPanel.port.emit('worker-ready-check');
+        } catch (ex) {} // eslint-disable-line no-empty
+      });
+    }
+  });
+}
+
+function _create(dimensions, panelOptions) {
+  // create() may be called by code that doesn't pass in the right arguments.
+  // To avoid causing problems, just store the config as userDimensions and userPanelOptions,
+  // then reuse those if no new argument is passed in. :beers:
+  userDimensions = dimensions || userDimensions || DEFAULT_DIMENSIONS;
+  userPanelOptions = panelOptions || userPanelOptions || Object.assign(DEFAULT_PANEL_OPTIONS, userDimensions);
+
+  // If we don't have a saved position from previous sessions, position relative
+  // to the bottom left corner of the opening window.
+  // Otherwise, the first time we create the panel, we need to offset the
+  // screenPosition by the window position to get to the correct screen
+  // location from the last session.
+  if (!isUserPosition) {
+    userPanelOptions.position = {bottom: 10, left: 10};
+  } else {
+    const currentWindow = Services.wm.getMostRecentWindow('navigator:browser');
+    userPanelOptions.position = {
+      top: screenPosition.y - currentWindow.mozInnerScreenY,
+      left: screenPosition.x - currentWindow.mozInnerScreenX
+    };
+  }
+
+  return require('sdk/panel').Panel(userPanelOptions);
+}
+
+function destroy() {
+  sdkPanel.port.removeListener('addon-message', messageHandler);
+  sdkPanel.dispose();
+  sdkPanel = null;
+  whenPanelReady.reset();
+}
+
+function getPanel() {
+  return sdkPanel;
+}
+
+// Call cb after the panel is in the XUL DOM and is a registered SDK view.
+// The checkCount can be omitted; it's used to track the recursion count.
+function _checkPanel(cb, checkCount) {
+  if (typeof checkCount !== 'number') { return _checkPanel(cb, 1) }
+
+  if (getActiveView(sdkPanel) && _getXulPanel()) return cb();
+
+  // TODO: if the check fails, should we destroy and create again? or just give up?
+  // TODO: is 10 seconds not long enough on ancient hardware?
+  if (checkCount > 100) return console.error('unable to find panel after 10 seconds'); // eslint-disable-line no-console
+  setTimeout(() => { _checkPanel(cb, ++checkCount); }, 100);
+  return;
+}
+
+function _getXulPanel() {
+  const currentWindow = Services.wm.getMostRecentWindow('navigator:browser');
+  const popups = currentWindow.document.getElementById('mainPopupSet');
+  const frame = popups.lastElementChild;
+
+  const isSdkPopup = frame.hasAttribute('sdkscriptenabled');
+  const minVidBackgroundFrame = frame.backgroundFrame &&
+                                  frame.backgroundFrame.getAttribute &&
+                                  frame.backgroundFrame.getAttribute('src').indexOf('min-vid') > -1;
+  const minVidViewFrame = frame.viewFrame && frame.viewFrame.getAttribute &&
+                            frame.viewFrame.getAttribute('src').indexOf('min-vid') > -1;
+
+  // if it's an sdk popup, and one of the frames has a min-vid src, it's the one we want.
+  return isSdkPopup && (minVidBackgroundFrame || minVidViewFrame);
+}
+
+function adjustHeight(newHeight) {
+  // Resize the panel by changing the height of the panel, iframe, and stack
+  // elements.
+  // On linux, makePanelDraggable isn't invoked, so the stack doesn't exist.
+  const xulPanel = getActiveView(sdkPanel);
+  const stack = xulPanel.getElementsByTagName('stack') && xulPanel.getElementsByTagName('stack')[0];
+  const frame = xulPanel.getElementsByTagName('iframe')[0];
+
+  frame.setAttribute('height', newHeight);
+  if (stack) stack.setAttribute('height', newHeight);
+  xulPanel.sizeTo(userDimensions.width, newHeight);
+
+  updatePosition(true);
+  redraw();
+}
+
+function redraw() {
+  setTimeout(() => {
+    const xulPanel = getActiveView(sdkPanel);
+    if (isUserPosition) {
+      // If the user has dragged the panel somewhere, reopen the panel at that
+      // screen position.
+      xulPanel.moveTo(screenPosition.x, screenPosition.y);
+    } else {
+      // If the user hasn't dragged the panel before, just open the panel at
+      // the bottom left corner of the currently active Firefox window.
+      xulPanel.moveToAnchor(xulPanel.ownerDocument.documentElement, 'bottomleft bottomleft', 10, -10);
+    }
+  }, 25);
+}
+
+function getPageUrl(domain, id, time) {
+  let url;
+  if (domain.indexOf('youtube') > -1) {
+    url = `https://youtube.com/watch?v=${id}&t=${Math.floor(time)}`;
+  } else if (domain.indexOf('vimeo') > -1) {
+    const min = Math.floor(time / 60);
+    const sec = Math.floor(time - min * 60);
+    url = `https://vimeo.com/${id}#t=${min}m${sec}s`;
+  } else if (domain.indexOf('vine') > -1) {
+    url = `https://vine.co/v/${id}`;
+  }
+
+  return url;
+}
+
+function messageHandler(opts) {
+  const title = opts.action;
+  const panel = getPanel();
+
+  if (title === 'send-to-tab') {
+    const pageUrl = getPageUrl(opts.domain, opts.id, opts.time);
+    if (pageUrl) require('sdk/tabs').open(pageUrl);
+    else {
+      console.error('could not parse page url for ', opts); // eslint-disable-line no-console
+      panel.port.emit('set-video', {error: 'Error loading video from ' + opts.domain});
+    }
+    panel.port.emit('set-video', {domain: '', src: ''});
+    panel.hide();
+  } else if (title === 'close') {
+    panel.port.emit('set-video', {domain: '', src: ''});
+    panel.hide();
+  } else if (title === 'minimize') {
+    adjustHeight(userDimensions.minimizedHeight);
+  } else if (title === 'maximize') {
+    adjustHeight(userDimensions.height);
+  } else if (title === 'metrics-event') {
+    // Note: sending in the panel ref to try to avoid circular imports.
+    sendMetricsData(opts, sdkPanel);
+  }
+}
+
+// If the panel doesn't exist, create it and return it.
+// If the panel does exist, but is attached to a different window, destroy it,
+// then create and return a new one on the correct window.
+// Otherwise, the panel exists on the current window, so just return it.
+function updateWindow() {
+  if (!sdkPanel) return create();
+  const currentWindow = Services.wm.getMostRecentWindow('navigator:browser');
+  const panelWindow = getActiveView(sdkPanel) && getActiveView(sdkPanel).ownerGlobal;
+
+  if (currentWindow !== panelWindow) {
+    destroy();
+    const panel = create();
+    whenPanelReady(redraw);
+    return panel;
+  }
+
+  return sdkPanel;
+}
+
+// isButtonClick: true if position is updated after clicking a button, falsy
+// if position is updated in response to a drag event.
+function updatePosition(isButtonClick) {
+  const panel = getActiveView(sdkPanel);
+  const window = panel.ownerGlobal;
+
+  // If the user hasn't dragged before, and didn't drag (clicked the minimize
+  // or un-minimize button), just redraw at default position. Otherwise, position
+  // relative to the screen, not the browser window.
+  if (isButtonClick && !isUserPosition) {
+    redraw();
+  } else {
+    const clientRect = panel.getBoundingClientRect();
+    const windowX = window.mozInnerScreenX;
+    const windowY = window.mozInnerScreenY;
+    const x = clientRect.left + windowX;
+    const y = clientRect.top + windowY;
+
+    screenPosition = {x: x, y: y};
+    isUserPosition = true;
+    // Write to simple storage later, because it's synchronous.
+    setTimeout(() => {
+      simpleStorage.storage.screenPosition = screenPosition;
+      simpleStorage.storage.isUserPosition = true;
+    });
+  }
+}
+
+module.exports = {
+  whenPanelReady: whenPanelReady,
+  create: create,
+  destroy: destroy,
+  getPanel: getPanel,
+  redraw: redraw,
+  updateWindow: updateWindow
+};

--- a/lib/send-metrics-data.js
+++ b/lib/send-metrics-data.js
@@ -4,12 +4,20 @@ const {Cu} = require('chrome');
 Cu.import('resource://gre/modules/Services.jsm');
 
 const { getActiveView } = require('sdk/view/core');
+const { setTimeout } = require('sdk/timers');
 
 module.exports = sendMetricsData;
 
 function sendMetricsData(o, panel) {
-  const coords = getActiveView(panel).getBoundingClientRect();
+  // Note: panel is optional, used to avoid circular refs with panel-utils.js.
+  panel = panel || require('./panel-utils.js').getPanel();
 
+  // If the panel's missing, try again a few seconds later.
+  if (!panel) {
+    return setTimeout(() => { sendMetricsData(o) }, 10 * 1000);
+  }
+
+  const coords = getActiveView(panel).getBoundingClientRect();
   // NOTE: this packet follows a predefined data format and cannot be changed
   //       without notifying the data team. See docs/metrics.md for more.
   const data = {


### PR DESCRIPTION
@meandavejustice Hey, mind taking a look? This could be a rough one; happy to walk you through it. Works great on my Mac, will try Win 10 in a bit.

-----

Other stuff:

- Carefully manage the panel startup lifecycle to avoid trying to send
  messages or access elements before they are ready.

- Persist the panel's screen location in simple-storage for consistency
  across sessions.

- Move panel lifecycle code to panel-utils, including a getPanel()
  function that helps us avoid accidentally breaking things by closing
  over a reference to a specific panel.

- Move panels to new windows by destroying, then re-creating at the old
	panel's coordinates.

- Add cachebusting query strings to content scripts/styles: Firefox caches
  frame scripts indefinitely[1]. Use cachebusting query strings to avoid stale
  code continuing to run after a restartless version upgrade or restartless
  uninstall-reinstall.

[1] See https://bugzil.la/1051238 as well as https://developer.mozilla.org/
    en-US/Firefox/Multiprocess_Firefox/Message_Manager/
    Frame_script_loading_and_lifetime#Frame_script_lifetime

Fixes #236, fixes #3.