### PR TITLE
Fix glitch with seeking while playing

### DIFF
--- a/components/player-view.js
+++ b/components/player-view.js
@@ -187,7 +187,7 @@ module.exports = React.createClass({
 
     if (this.isYt) {
       ytCtrl.setTime(window.AppData.duration * clickedValue);
-      ytCtrl.forceUpdateTime();
+      if (!this.props.playing) ytCtrl.forceUpdateTime();
     } else {
       this.refs.video.currentTime = window.AppData.duration * clickedValue;
     }


### PR DESCRIPTION
- There was a regression when fixing #259, where instead
of forcing ytplayer to play then resume pause when paused
we were doing it when seeking while the video was playing
as well, causing a playing video to pause after seeking,
instead of resuming. (Does that make any sense??)
- fixes #277