### PR TITLE
Fix min-vid by copy-pasting last working SDK panel.js

### DIFF
--- a/lib/mysdk/panel.js
+++ b/lib/mysdk/panel.js
@@ -1,0 +1,389 @@
+// This is a version of the SDK panel.js file from 8 September 2016
+// https://github.com/mozilla/gecko-dev/blob/4cf6a90/addon-sdk/source/lib/sdk/panel.js
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+// The panel module currently supports only Firefox and SeaMonkey.
+// See: https://bugzilla.mozilla.org/show_bug.cgi?id=jetpack-panel-apps
+module.metadata = {
+  "stability": "stable",
+  "engines": {
+    "Firefox": "*",
+    "SeaMonkey": "*"
+  }
+};
+
+const { Ci } = require("chrome");
+const { setTimeout } = require('./timers');
+const { Class } = require("./core/heritage");
+const { merge } = require("./util/object");
+const { WorkerHost } = require("./content/utils");
+const { Worker } = require("./deprecated/sync-worker");
+const { Disposable } = require("./core/disposable");
+const { WeakReference } = require('./core/reference');
+const { contract: loaderContract } = require("./content/loader");
+const { contract } = require("./util/contract");
+const { on, off, emit, setListeners } = require("./event/core");
+const { EventTarget } = require("./event/target");
+const domPanel = require("./panel/utils");
+const { getDocShell } = require('./frame/utils');
+const { events } = require("./panel/events");
+const systemEvents = require("./system/events");
+const { filter, pipe, stripListeners } = require("./event/utils");
+const { getNodeView, getActiveView } = require("./view/core");
+const { isNil, isObject, isNumber } = require("./lang/type");
+const { getAttachEventType } = require("./content/utils");
+const { number, boolean, object } = require('./deprecated/api-utils');
+const { Style } = require("./stylesheet/style");
+const { attach, detach } = require("./content/mod");
+
+var isRect = ({top, right, bottom, left}) => [top, right, bottom, left].
+  some(value => isNumber(value) && !isNaN(value));
+
+var isSDKObj = obj => obj instanceof Class;
+
+var rectContract = contract({
+  top: number,
+  right: number,
+  bottom: number,
+  left: number
+});
+
+var position = {
+  is: object,
+  map: v => (isNil(v) || isSDKObj(v) || !isObject(v)) ? v : rectContract(v),
+  ok: v => isNil(v) || isSDKObj(v) || (isObject(v) && isRect(v)),
+  msg: 'The option "position" must be a SDK object registered as anchor; ' +
+        'or an object with one or more of the following keys set to numeric ' +
+        'values: top, right, bottom, left.'
+}
+
+var displayContract = contract({
+  width: number,
+  height: number,
+  focus: boolean,
+  position: position
+});
+
+var panelContract = contract(merge({
+  // contentStyle* / contentScript* are sharing the same validation constraints,
+  // so they can be mostly reused, except for the messages.
+  contentStyle: merge(Object.create(loaderContract.rules.contentScript), {
+    msg: 'The `contentStyle` option must be a string or an array of strings.'
+  }),
+  contentStyleFile: merge(Object.create(loaderContract.rules.contentScriptFile), {
+    msg: 'The `contentStyleFile` option must be a local URL or an array of URLs'
+  }),
+  contextMenu: boolean,
+  allow: {
+    is: ['object', 'undefined', 'null'],
+    map: function (allow) { return { script: !allow || allow.script !== false }}
+  },
+}, displayContract.rules, loaderContract.rules));
+
+function Allow(panel) {
+  return {
+    get script() { return getDocShell(viewFor(panel).backgroundFrame).allowJavascript; },
+    set script(value) { return setScriptState(panel, value); },
+  };
+}
+
+function setScriptState(panel, value) {
+  let view = viewFor(panel);
+  getDocShell(view.backgroundFrame).allowJavascript = value;
+  getDocShell(view.viewFrame).allowJavascript = value;
+  view.setAttribute("sdkscriptenabled", "" + value);
+}
+
+function isDisposed(panel) {
+  return !views.has(panel);
+}
+
+var panels = new WeakMap();
+var models = new WeakMap();
+var views = new WeakMap();
+var workers = new WeakMap();
+var styles = new WeakMap();
+
+const viewFor = (panel) => views.get(panel);
+const modelFor = (panel) => models.get(panel);
+const panelFor = (view) => panels.get(view);
+const workerFor = (panel) => workers.get(panel);
+const styleFor = (panel) => styles.get(panel);
+
+// Utility function takes `panel` instance and makes sure it will be
+// automatically hidden as soon as other panel is shown.
+var setupAutoHide = new function() {
+  let refs = new WeakMap();
+
+  return function setupAutoHide(panel) {
+    // Create system event listener that reacts to any panel showing and
+    // hides given `panel` if it's not the one being shown.
+    function listener({subject}) {
+      // It could be that listener is not GC-ed in the same cycle as
+      // panel in such case we remove listener manually.
+      let view = viewFor(panel);
+      if (!view) systemEvents.off("popupshowing", listener);
+      else if (subject !== view) panel.hide();
+    }
+
+    // system event listener is intentionally weak this way we'll allow GC
+    // to claim panel if it's no longer referenced by an add-on code. This also
+    // helps minimizing cleanup required on unload.
+    systemEvents.on("popupshowing", listener);
+    // To make sure listener is not claimed by GC earlier than necessary we
+    // associate it with `panel` it's associated with. This way it won't be
+    // GC-ed earlier than `panel` itself.
+    refs.set(panel, listener);
+  }
+}
+
+const Panel = Class({
+  implements: [
+    // Generate accessors for the validated properties that update model on
+    // set and return values from model on get.
+    panelContract.properties(modelFor),
+    EventTarget,
+    Disposable,
+    WeakReference
+  ],
+  extends: WorkerHost(workerFor),
+  setup: function setup(options) {
+    let model = merge({
+      defaultWidth: 320,
+      defaultHeight: 240,
+      focus: true,
+      position: Object.freeze({}),
+      contextMenu: false
+    }, panelContract(options));
+    model.ready = false;
+    models.set(this, model);
+
+    if (model.contentStyle || model.contentStyleFile) {
+      styles.set(this, Style({
+        uri: model.contentStyleFile,
+        source: model.contentStyle
+      }));
+    }
+
+    // Setup view
+    let viewOptions = {allowJavascript: !model.allow || (model.allow.script !== false)};
+    let view = domPanel.make(null, viewOptions);
+    panels.set(view, this);
+    views.set(this, view);
+
+    // Load panel content.
+    domPanel.setURL(view, model.contentURL);
+
+    // Allow context menu
+    domPanel.allowContextMenu(view, model.contextMenu);
+
+    setupAutoHide(this);
+
+    // Setup listeners.
+    setListeners(this, options);
+    let worker = new Worker(stripListeners(options));
+    workers.set(this, worker);
+
+    // pipe events from worker to a panel.
+    pipe(worker, this);
+  },
+  dispose: function dispose() {
+    this.hide();
+    off(this);
+
+    workerFor(this).destroy();
+    detach(styleFor(this));
+
+    domPanel.dispose(viewFor(this));
+
+    // Release circular reference between view and panel instance. This
+    // way view will be GC-ed. And panel as well once all the other refs
+    // will be removed from it.
+    views.delete(this);
+  },
+  /* Public API: Panel.width */
+  get width() {
+    return modelFor(this).width;
+  },
+  set width(value) {
+    this.resize(value, this.height);
+  },
+  /* Public API: Panel.height */
+  get height() {
+    return modelFor(this).height;
+  },
+  set height(value) {
+    this.resize(this.width, value);
+  },
+
+  /* Public API: Panel.focus */
+  get focus() {
+    return modelFor(this).focus;
+  },
+
+  /* Public API: Panel.position */
+  get position() {
+    return modelFor(this).position;
+  },
+
+  /* Public API: Panel.contextMenu */
+  get contextMenu() {
+    return modelFor(this).contextMenu;
+  },
+  set contextMenu(allow) {
+    let model = modelFor(this);
+    model.contextMenu = panelContract({ contextMenu: allow }).contextMenu;
+    domPanel.allowContextMenu(viewFor(this), model.contextMenu);
+  },
+
+  get contentURL() {
+    return modelFor(this).contentURL;
+  },
+  set contentURL(value) {
+    let model = modelFor(this);
+    model.contentURL = panelContract({ contentURL: value }).contentURL;
+    domPanel.setURL(viewFor(this), model.contentURL);
+    // Detach worker so that messages send will be queued until it's
+    // reatached once panel content is ready.
+    workerFor(this).detach();
+  },
+
+  get allow() { return Allow(this); },
+  set allow(value) {
+    let allowJavascript = panelContract({ allow: value }).allow.script;
+    return setScriptState(this, value);
+  },
+
+  /* Public API: Panel.isShowing */
+  get isShowing() {
+    return !isDisposed(this) && domPanel.isOpen(viewFor(this));
+  },
+
+  /* Public API: Panel.show */
+  show: function show(options={}, anchor) {
+    if (options instanceof Ci.nsIDOMElement) {
+      [anchor, options] = [options, null];
+    }
+
+    if (anchor instanceof Ci.nsIDOMElement) {
+      console.warn(
+        "Passing a DOM node to Panel.show() method is an unsupported " +
+        "feature that will be soon replaced. " +
+        "See: https://bugzilla.mozilla.org/show_bug.cgi?id=878877"
+      );
+    }
+
+    let model = modelFor(this);
+    let view = viewFor(this);
+    let anchorView = getNodeView(anchor || options.position || model.position);
+
+    options = merge({
+      position: model.position,
+      width: model.width,
+      height: model.height,
+      defaultWidth: model.defaultWidth,
+      defaultHeight: model.defaultHeight,
+      focus: model.focus,
+      contextMenu: model.contextMenu
+    }, displayContract(options));
+
+    if (!isDisposed(this))
+      domPanel.show(view, options, anchorView);
+
+    return this;
+  },
+
+  /* Public API: Panel.hide */
+  hide: function hide() {
+    // Quit immediately if panel is disposed or there is no state change.
+    domPanel.close(viewFor(this));
+
+    return this;
+  },
+
+  /* Public API: Panel.resize */
+  resize: function resize(width, height) {
+    let model = modelFor(this);
+    let view = viewFor(this);
+    let change = panelContract({
+      width: width || model.width || model.defaultWidth,
+      height: height || model.height || model.defaultHeight
+    });
+
+    model.width = change.width
+    model.height = change.height
+
+    domPanel.resize(view, model.width, model.height);
+
+    return this;
+  }
+});
+exports.Panel = Panel;
+
+// Note must be defined only after value to `Panel` is assigned.
+getActiveView.define(Panel, viewFor);
+
+// Filter panel events to only panels that are create by this module.
+var panelEvents = filter(events, ({target}) => panelFor(target));
+
+// Panel events emitted after panel has being shown.
+var shows = filter(panelEvents, ({type}) => type === "popupshown");
+
+// Panel events emitted after panel became hidden.
+var hides = filter(panelEvents, ({type}) => type === "popuphidden");
+
+// Panel events emitted after content inside panel is ready. For different
+// panels ready may mean different state based on `contentScriptWhen` attribute.
+// Weather given event represents readyness is detected by `getAttachEventType`
+// helper function.
+var ready = filter(panelEvents, ({type, target}) =>
+  getAttachEventType(modelFor(panelFor(target))) === type);
+
+// Panel event emitted when the contents of the panel has been loaded.
+var readyToShow = filter(panelEvents, ({type}) => type === "DOMContentLoaded");
+
+// Styles should be always added as soon as possible, and doesn't makes them
+// depends on `contentScriptWhen`
+var start = filter(panelEvents, ({type}) => type === "document-element-inserted");
+
+// Forward panel show / hide events to panel's own event listeners.
+on(shows, "data", ({target}) => {
+  let panel = panelFor(target);
+  if (modelFor(panel).ready)
+    emit(panel, "show");
+});
+
+on(hides, "data", ({target}) => {
+  let panel = panelFor(target);
+  if (modelFor(panel).ready)
+    emit(panel, "hide");
+});
+
+on(ready, "data", ({target}) => {
+  let panel = panelFor(target);
+  let window = domPanel.getContentDocument(target).defaultView;
+
+  workerFor(panel).attach(window);
+});
+
+on(readyToShow, "data", ({target}) => {
+  let panel = panelFor(target);
+
+  if (!modelFor(panel).ready) {
+    modelFor(panel).ready = true;
+
+    if (viewFor(panel).state == "open")
+      emit(panel, "show");
+  }
+});
+
+on(start, "data", ({target}) => {
+  let panel = panelFor(target);
+  let window = domPanel.getContentDocument(target).defaultView;
+
+  attach(styleFor(panel), window);
+});

--- a/lib/mysdk/panel.js
+++ b/lib/mysdk/panel.js
@@ -1,6 +1,8 @@
 // This is a version of the SDK panel.js file from 8 September 2016
 // https://github.com/mozilla/gecko-dev/blob/4cf6a90/addon-sdk/source/lib/sdk/panel.js
 
+/* eslint-disable */
+
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
@@ -17,28 +19,30 @@ module.metadata = {
 };
 
 const { Ci } = require("chrome");
-const { setTimeout } = require('./timers');
-const { Class } = require("./core/heritage");
-const { merge } = require("./util/object");
-const { WorkerHost } = require("./content/utils");
-const { Worker } = require("./deprecated/sync-worker");
-const { Disposable } = require("./core/disposable");
-const { WeakReference } = require('./core/reference');
-const { contract: loaderContract } = require("./content/loader");
-const { contract } = require("./util/contract");
-const { on, off, emit, setListeners } = require("./event/core");
-const { EventTarget } = require("./event/target");
+const { setTimeout } = require('sdk/timers');
+const { Class } = require("sdk/core/heritage");
+const { merge } = require("sdk/util/object");
+const { WorkerHost } = require("sdk/content/utils");
+const { Worker } = require("sdk/deprecated/sync-worker");
+const { Disposable } = require("sdk/core/disposable");
+const { WeakReference } = require('sdk/core/reference');
+const { contract: loaderContract } = require("sdk/content/loader");
+const { contract } = require("sdk/util/contract");
+const { on, off, emit, setListeners } = require("sdk/event/core");
+const { EventTarget } = require("sdk/event/target");
+const { getDocShell } = require('sdk/frame/utils');
+const { events } = require("sdk/panel/events");
+const systemEvents = require("sdk/system/events");
+const { filter, pipe, stripListeners } = require("sdk/event/utils");
+const { getNodeView, getActiveView } = require("sdk/view/core");
+const { isNil, isObject, isNumber } = require("sdk/lang/type");
+const { getAttachEventType } = require("sdk/content/utils");
+const { number, boolean, object } = require('sdk/deprecated/api-utils');
+const { Style } = require("sdk/stylesheet/style");
+const { attach, detach } = require("sdk/content/mod");
+
+// NOTE: we had to copypasta this one, too
 const domPanel = require("./panel/utils");
-const { getDocShell } = require('./frame/utils');
-const { events } = require("./panel/events");
-const systemEvents = require("./system/events");
-const { filter, pipe, stripListeners } = require("./event/utils");
-const { getNodeView, getActiveView } = require("./view/core");
-const { isNil, isObject, isNumber } = require("./lang/type");
-const { getAttachEventType } = require("./content/utils");
-const { number, boolean, object } = require('./deprecated/api-utils');
-const { Style } = require("./stylesheet/style");
-const { attach, detach } = require("./content/mod");
 
 var isRect = ({top, right, bottom, left}) => [top, right, bottom, left].
   some(value => isNumber(value) && !isNaN(value));

--- a/lib/mysdk/panel/utils.js
+++ b/lib/mysdk/panel/utils.js
@@ -1,6 +1,8 @@
 // This is a version of the SDK panel/utils.js file from 8 September 2016
 // https://github.com/mozilla/gecko-dev/blob/4cf6a90/addon-sdk/source/lib/sdk/panel/utils.js
 
+/* eslint-disable */
+
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
@@ -12,17 +14,17 @@ module.metadata = {
 };
 
 const { Cc, Ci } = require("chrome");
-const { setTimeout } = require("../timers");
-const { platform } = require("../system");
+const { setTimeout } = require("sdk/timers");
+const { platform } = require("sdk/system");
 const { getMostRecentBrowserWindow, getOwnerBrowserWindow,
-        getHiddenWindow, getScreenPixelsPerCSSPixel } = require("../window/utils");
+        getHiddenWindow, getScreenPixelsPerCSSPixel } = require("sdk/window/utils");
 
-const { create: createFrame, swapFrameLoaders, getDocShell } = require("../frame/utils");
-const { window: addonWindow } = require("../addon/window");
-const { isNil } = require("../lang/type");
-const { data } = require('../self');
+const { create: createFrame, swapFrameLoaders, getDocShell } = require("sdk/frame/utils");
+const { window: addonWindow } = require("sdk/addon/window");
+const { isNil } = require("sdk/lang/type");
+const { data } = require('sdk/self');
 
-const events = require("../system/events");
+const events = require("sdk/system/events");
 
 
 const XUL_NS = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";

--- a/lib/mysdk/panel/utils.js
+++ b/lib/mysdk/panel/utils.js
@@ -1,0 +1,455 @@
+// This is a version of the SDK panel/utils.js file from 8 September 2016
+// https://github.com/mozilla/gecko-dev/blob/4cf6a90/addon-sdk/source/lib/sdk/panel/utils.js
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+module.metadata = {
+  "stability": "unstable"
+};
+
+const { Cc, Ci } = require("chrome");
+const { setTimeout } = require("../timers");
+const { platform } = require("../system");
+const { getMostRecentBrowserWindow, getOwnerBrowserWindow,
+        getHiddenWindow, getScreenPixelsPerCSSPixel } = require("../window/utils");
+
+const { create: createFrame, swapFrameLoaders, getDocShell } = require("../frame/utils");
+const { window: addonWindow } = require("../addon/window");
+const { isNil } = require("../lang/type");
+const { data } = require('../self');
+
+const events = require("../system/events");
+
+
+const XUL_NS = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
+
+function calculateRegion({ position, width, height, defaultWidth, defaultHeight }, rect) {
+  position = position || {};
+
+  let x, y;
+
+  let hasTop = !isNil(position.top);
+  let hasRight = !isNil(position.right);
+  let hasBottom = !isNil(position.bottom);
+  let hasLeft = !isNil(position.left);
+  let hasWidth = !isNil(width);
+  let hasHeight = !isNil(height);
+
+  // if width is not specified by constructor or show's options, then get
+  // the default width
+  if (!hasWidth)
+    width = defaultWidth;
+
+  // if height is not specified by constructor or show's options, then get
+  // the default height
+  if (!hasHeight)
+    height = defaultHeight;
+
+  // default position is centered
+  x = (rect.right - width) / 2;
+  y = (rect.top + rect.bottom - height) / 2;
+
+  if (hasTop) {
+    y = rect.top + position.top;
+
+    if (hasBottom && !hasHeight)
+      height = rect.bottom - position.bottom - y;
+  }
+  else if (hasBottom) {
+    y = rect.bottom - position.bottom - height;
+  }
+
+  if (hasLeft) {
+    x = position.left;
+
+    if (hasRight && !hasWidth)
+      width = rect.right - position.right - x;
+  }
+  else if (hasRight) {
+    x = rect.right - width - position.right;
+  }
+
+  return {x: x, y: y, width: width, height: height};
+}
+
+function open(panel, options, anchor) {
+  // Wait for the XBL binding to be constructed
+  if (!panel.openPopup) setTimeout(open, 50, panel, options, anchor);
+  else display(panel, options, anchor);
+}
+exports.open = open;
+
+function isOpen(panel) {
+  return panel.state === "open"
+}
+exports.isOpen = isOpen;
+
+function isOpening(panel) {
+  return panel.state === "showing"
+}
+exports.isOpening = isOpening
+
+function close(panel) {
+  // Sometimes "TypeError: panel.hidePopup is not a function" is thrown
+  // when quitting the host application while a panel is visible.  To suppress
+  // these errors, check for "hidePopup" in panel before calling it.
+  // It's not clear if there's an issue or it's expected behavior.
+  // See Bug 1151796.
+
+  return panel.hidePopup && panel.hidePopup();
+}
+exports.close = close
+
+
+function resize(panel, width, height) {
+  // Resize the iframe instead of using panel.sizeTo
+  // because sizeTo doesn't work with arrow panels
+  panel.firstChild.style.width = width + "px";
+  panel.firstChild.style.height = height + "px";
+}
+exports.resize = resize
+
+function display(panel, options, anchor) {
+  let document = panel.ownerDocument;
+
+  let x, y;
+  let { width, height, defaultWidth, defaultHeight } = options;
+
+  let popupPosition = null;
+
+  // Panel XBL has some SDK incompatible styling decisions. We shim panel
+  // instances until proper fix for Bug 859504 is shipped.
+  shimDefaultStyle(panel);
+
+  if (!anchor) {
+    // The XUL Panel doesn't have an arrow, so the margin needs to be reset
+    // in order to, be positioned properly
+    panel.style.margin = "0";
+
+    let viewportRect = document.defaultView.gBrowser.getBoundingClientRect();
+
+    ({x, y, width, height} = calculateRegion(options, viewportRect));
+  }
+  else {
+    // The XUL Panel has an arrow, so the margin needs to be reset
+    // to the default value.
+    panel.style.margin = "";
+    let { CustomizableUI, window } = anchor.ownerDocument.defaultView;
+
+    // In Australis, widgets may be positioned in an overflow panel or the
+    // menu panel.
+    // In such cases clicking this widget will hide the overflow/menu panel,
+    // and the widget's panel will show instead.
+    // If `CustomizableUI` is not available, it means the anchor is not in a
+    // chrome browser window, and therefore there is no need for this check.
+    if (CustomizableUI) {
+      let node = anchor;
+      ({anchor} = CustomizableUI.getWidget(anchor.id).forWindow(window));
+
+      // if `node` is not the `anchor` itself, it means the widget is
+      // positioned in a panel, therefore we have to hide it before show
+      // the widget's panel in the same anchor
+      if (node !== anchor)
+        CustomizableUI.hidePanelForNode(anchor);
+    }
+
+    width = width || defaultWidth;
+    height = height || defaultHeight;
+
+    // Open the popup by the anchor.
+    let rect = anchor.getBoundingClientRect();
+
+    let zoom = getScreenPixelsPerCSSPixel(window);
+    let screenX = rect.left + window.mozInnerScreenX * zoom;
+    let screenY = rect.top + window.mozInnerScreenY * zoom;
+
+    // Set up the vertical position of the popup relative to the anchor
+    // (always display the arrow on anchor center)
+    let horizontal, vertical;
+    if (screenY > window.screen.availHeight / 2 + height)
+      vertical = "top";
+    else
+      vertical = "bottom";
+
+    if (screenY > window.screen.availWidth / 2 + width)
+      horizontal = "left";
+    else
+      horizontal = "right";
+
+    let verticalInverse = vertical == "top" ? "bottom" : "top";
+    popupPosition = vertical + "center " + verticalInverse + horizontal;
+
+    // Allow panel to flip itself if the panel can't be displayed at the
+    // specified position (useful if we compute a bad position or if the
+    // user moves the window and panel remains visible)
+    panel.setAttribute("flip", "both");
+  }
+
+  // Resize the iframe instead of using panel.sizeTo
+  // because sizeTo doesn't work with arrow panels
+  panel.firstChild.style.width = width + "px";
+  panel.firstChild.style.height = height + "px";
+
+  panel.openPopup(anchor, popupPosition, x, y);
+}
+exports.display = display;
+
+// This utility function is just a workaround until Bug 859504 has shipped.
+function shimDefaultStyle(panel) {
+  let document = panel.ownerDocument;
+  // Please note that `panel` needs to be part of document in order to reach
+  // it's anonymous nodes. One of the anonymous node has a big padding which
+  // doesn't work well since panel frame needs to fill all of the panel.
+  // XBL binding is a not the best option as it's applied asynchronously, and
+  // makes injected frames behave in strange way. Also this feels a lot
+  // cheaper to do.
+  ["panel-inner-arrowcontent", "panel-arrowcontent"].forEach(function(value) {
+    let node = document.getAnonymousElementByAttribute(panel, "class", value);
+      if (node) node.style.padding = 0;
+  });
+}
+
+function show(panel, options, anchor) {
+  // Prevent the panel from getting focus when showing up
+  // if focus is set to false
+  panel.setAttribute("noautofocus", !options.focus);
+
+  let window = anchor && getOwnerBrowserWindow(anchor);
+  let { document } = window ? window : getMostRecentBrowserWindow();
+  attach(panel, document);
+
+  open(panel, options, anchor);
+}
+exports.show = show
+
+function onPanelClick(event) {
+  let { target, metaKey, ctrlKey, shiftKey, button } = event;
+  let accel = platform === "darwin" ? metaKey : ctrlKey;
+  let isLeftClick = button === 0;
+  let isMiddleClick = button === 1;
+
+  if ((isLeftClick && (accel || shiftKey)) || isMiddleClick) {
+    let link = target.closest('a');
+
+    if (link && link.href)
+       getMostRecentBrowserWindow().openUILink(link.href, event)
+  }
+}
+
+function setupPanelFrame(frame) {
+  frame.setAttribute("flex", 1);
+  frame.setAttribute("transparent", "transparent");
+  frame.setAttribute("autocompleteenabled", true);
+  frame.setAttribute("tooltip", "aHTMLTooltip");
+  if (platform === "darwin") {
+    frame.style.borderRadius = "6px";
+    frame.style.padding = "1px";
+  }
+}
+
+function make(document, options) {
+  document = document || getMostRecentBrowserWindow().document;
+  let panel = document.createElementNS(XUL_NS, "panel");
+  panel.setAttribute("type", "arrow");
+  panel.setAttribute("sdkscriptenabled", "" + options.allowJavascript);
+
+  // Note that panel is a parent of `viewFrame` who's `docShell` will be
+  // configured at creation time. If `panel` and there for `viewFrame` won't
+  // have an owner document attempt to access `docShell` will throw. There
+  // for we attach panel to a document.
+  attach(panel, document);
+
+  let frameOptions =  {
+    allowJavascript: options.allowJavascript,
+    allowPlugins: true,
+    allowAuth: true,
+    allowWindowControl: false,
+    // Need to override `nodeName` to use `iframe` as `browsers` save session
+    // history and in consequence do not dispatch "inner-window-destroyed"
+    // notifications.
+    browser: false,
+    // Note that use of this URL let's use swap frame loaders earlier
+    // than if we used default "about:blank".
+    uri: "data:text/plain;charset=utf-8,"
+  };
+
+  let backgroundFrame = createFrame(addonWindow, frameOptions);
+  setupPanelFrame(backgroundFrame);
+
+  let viewFrame = createFrame(panel, frameOptions);
+  setupPanelFrame(viewFrame);
+
+  function onDisplayChange({type, target}) {
+    // Events from child element like <select /> may propagate (dropdowns are
+    // popups too), in which case frame loader shouldn't be swapped.
+    // See Bug 886329
+    if (target !== this) return;
+
+    try {
+      swapFrameLoaders(backgroundFrame, viewFrame);
+      // We need to re-set this because... swapFrameLoaders. Or something.
+      let shouldEnableScript = panel.getAttribute("sdkscriptenabled") == "true";
+      getDocShell(backgroundFrame).allowJavascript = shouldEnableScript;
+      getDocShell(viewFrame).allowJavascript = shouldEnableScript;
+    }
+    catch(error) {
+      console.exception(error);
+    }
+    events.emit(type, { subject: panel });
+  }
+
+  function onContentReady({target, type}) {
+    if (target === getContentDocument(panel)) {
+      style(panel);
+      events.emit(type, { subject: panel });
+    }
+  }
+
+  function onContentLoad({target, type}) {
+    if (target === getContentDocument(panel))
+      events.emit(type, { subject: panel });
+  }
+
+  function onContentChange({subject: document, type}) {
+    if (document === getContentDocument(panel) && document.defaultView)
+      events.emit(type, { subject: panel });
+  }
+
+  function onPanelStateChange({type}) {
+    events.emit(type, { subject: panel })
+  }
+
+  panel.addEventListener("popupshowing", onDisplayChange, false);
+  panel.addEventListener("popuphiding", onDisplayChange, false);
+  panel.addEventListener("popupshown", onPanelStateChange, false);
+  panel.addEventListener("popuphidden", onPanelStateChange, false);
+
+  panel.addEventListener("click", onPanelClick, false);
+
+  // Panel content document can be either in panel `viewFrame` or in
+  // a `backgroundFrame` depending on panel state. Listeners are set
+  // on both to avoid setting and removing listeners on panel state changes.
+
+  panel.addEventListener("DOMContentLoaded", onContentReady, true);
+  backgroundFrame.addEventListener("DOMContentLoaded", onContentReady, true);
+
+  panel.addEventListener("load", onContentLoad, true);
+  backgroundFrame.addEventListener("load", onContentLoad, true);
+
+  events.on("document-element-inserted", onContentChange);
+
+
+  panel.backgroundFrame = backgroundFrame;
+  panel.viewFrame = viewFrame;
+
+  // Store event listener on the panel instance so that it won't be GC-ed
+  // while panel is alive.
+  panel.onContentChange = onContentChange;
+
+  return panel;
+}
+exports.make = make;
+
+function attach(panel, document) {
+  document = document || getMostRecentBrowserWindow().document;
+  let container = document.getElementById("mainPopupSet");
+  if (container !== panel.parentNode) {
+    detach(panel);
+    document.getElementById("mainPopupSet").appendChild(panel);
+  }
+}
+exports.attach = attach;
+
+function detach(panel) {
+  if (panel.parentNode) panel.parentNode.removeChild(panel);
+}
+exports.detach = detach;
+
+function dispose(panel) {
+  panel.backgroundFrame.remove();
+  panel.viewFrame.remove();
+  panel.backgroundFrame = null;
+  panel.viewFrame = null;
+  events.off("document-element-inserted", panel.onContentChange);
+  panel.onContentChange = null;
+  detach(panel);
+}
+exports.dispose = dispose;
+
+function style(panel) {
+  /**
+  Injects default OS specific panel styles into content document that is loaded
+  into given panel. Optionally `document` of the browser window can be
+  given to inherit styles from it, by default it will use either panel owner
+  document or an active browser's document. It should not matter though unless
+  Firefox decides to style windows differently base on profile or mode like
+  chrome for example.
+  **/
+
+  try {
+    let document = panel.ownerDocument;
+    let contentDocument = getContentDocument(panel);
+    let window = document.defaultView;
+    let node = document.getAnonymousElementByAttribute(panel, "class",
+                                                       "panel-arrowcontent") ||
+               // Before bug 764755, anonymous content was different:
+               // TODO: Remove this when targeting FF16+
+                document.getAnonymousElementByAttribute(panel, "class",
+                                                        "panel-inner-arrowcontent");
+
+    let { color, fontFamily, fontSize, fontWeight } = window.getComputedStyle(node);
+
+    let style = contentDocument.createElement("style");
+    style.id = "sdk-panel-style";
+    style.textContent = "body { " +
+      "color: " + color + ";" +
+      "font-family: " + fontFamily + ";" +
+      "font-weight: " + fontWeight + ";" +
+      "font-size: " + fontSize + ";" +
+    "}";
+
+    let container = contentDocument.head ? contentDocument.head :
+                    contentDocument.documentElement;
+
+    if (container.firstChild)
+      container.insertBefore(style, container.firstChild);
+    else
+      container.appendChild(style);
+  }
+  catch (error) {
+    console.error("Unable to apply panel style");
+    console.exception(error);
+  }
+}
+exports.style = style;
+
+var getContentFrame = panel =>
+    (isOpen(panel) || isOpening(panel)) ?
+    panel.firstChild :
+    panel.backgroundFrame
+exports.getContentFrame = getContentFrame;
+
+function getContentDocument(panel) {
+  return getContentFrame(panel).contentDocument;
+}
+exports.getContentDocument = getContentDocument;
+
+function setURL(panel, url) {
+  getContentFrame(panel).setAttribute("src", url ? data.url(url) : url);
+}
+
+exports.setURL = setURL;
+
+function allowContextMenu(panel, allow) {
+  if (allow) {
+    panel.setAttribute("context", "contentAreaContextMenu");
+  }
+  else {
+    panel.removeAttribute("context");
+  }
+}
+exports.allowContextMenu = allowContextMenu;

--- a/lib/panel-utils.js
+++ b/lib/panel-utils.js
@@ -188,7 +188,7 @@ function _create(dimensions, panelOptions) {
     };
   }
 
-  return require('sdk/panel').Panel(userPanelOptions);
+  return require('./mysdk/panel').Panel(userPanelOptions);
 }
 
 function destroy() {


### PR DESCRIPTION
Instead of disabling our XUL code because of breaking changes in the SDK panel code, what if we just copy over the SDK panel files that changed? Copy the latest working versions, check them into the repo, leave everything else the same. This approach actually works!

So, this branch introduces copies of `sdk/panel.js` and `sdk/panel/utils.js` from just before the breaking changes landed. We use the regular SDK code for all other dependencies.

The goal here is to **temporarily** fix dragging behavior, until I have a chance to develop a better fix. As long as we don't leave the stale files in here for too long, I think the risk is reasonable.

Refs issue #307.