### PR TITLE
Update eslint to flag lack of spaces after keywords and before blocks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,3 +28,5 @@ rules:
   no-var: 1
   prefer-const: 2
   quotes: [2, single, {avoidEscape: true, allowTemplateLiterals: true}]
+  space-before-blocks: 2
+  keyword-spacing: 2


### PR DESCRIPTION
I updated the eslintrc file to automatically flag the nits pointed out during the review of #398.