### PR TITLE
Fix missing metrics pings and update metrics docs

### DIFF
--- a/components/error-view.js
+++ b/components/error-view.js
@@ -29,6 +29,7 @@ module.exports = React.createClass({
     });
   },
   render: function() {
+    sendMetricsEvent('error_view', 'render');
     return (
         <div className='error' onMouseEnter={this.enterView} onMouseLeave={this.leaveView}>
           <ReactTooltip place='bottom' effect='solid' />

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -45,13 +45,9 @@ otherwise noted.
     * Sent when the error view is displayed (a video failed to load).
 
 * Object: `loading_view`
-  * method: `render`
-    * Sent when the loading view is displayed.
   * method: `close`
 
 * Object: `player_view`
-  * method: `render`
-    * Sent when the player view is displayed.
   * method: `video_loaded`
     * Sent when the video has loaded in the player view.
   * method: `video_ended`

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ exports.main = function() {
           launchVideo(opts);
         }
       });
-      worker.port.on('metrics', sendMetricsData);
+      worker.port.on('metric', sendMetricsData);
     }
   });
 

--- a/lib/context-menu-handlers.js
+++ b/lib/context-menu-handlers.js
@@ -60,14 +60,14 @@ function getItem(opts) {
 
 function init() {
   const onMessageVimeoHandler = (url) => {
-    sendMetricsData({changed: 'activate', domain: 'vimeo.com'});
+    sendMetricsData({object: 'contextmenu', method: 'activate', domain: 'vimeo.com'});
     launchVideo({url: url,
                  domain: 'vimeo.com',
                  getUrlFn: getVimeoUrl});
   };
 
   const onMessageYouTubeHandler = (url) => {
-    sendMetricsData({changed: 'activate', domain: 'youtube.com'});
+    sendMetricsData({object: 'contextmenu', method: 'activate', domain: 'youtube.com'});
     launchVideo({url: url,
                  domain: 'youtube.com',
                  getUrlFn: getYouTubeUrl});
@@ -177,7 +177,7 @@ function init() {
     context: cm.SelectorContext(getSelectors('vine')),
     contentScript: contextMenuContentScript,
     onMessage: function(url) {
-      sendMetricsData({changed: 'activate', domain: 'vine.co'});
+      sendMetricsData({object: 'contextmenu', method: 'activate', domain: 'vine.co'});
       launchVideo({url: url,
                    domain: 'vine.co',
                    getUrlFn: getVineUrl});
@@ -195,7 +195,7 @@ function init() {
     });`,
     onMessage: function(url) {
       const mp4 = url.replace(/thumbs/, 'videos').split(/\.jpg/)[0];
-      sendMetricsData({changed: 'activate', domain: 'vine.co'});
+      sendMetricsData({object: 'contextmenu', method: 'activate', domain: 'vine.co'});
       launchVideo({url: url,
                    domain: 'vine.co',
                    src: mp4});
@@ -227,7 +227,7 @@ function init() {
         domain = 'vine.co';
       }
       if (domain && getUrlFn) {
-        sendMetricsData({changed: 'activate', domain: domain});
+        sendMetricsData({object: 'contextmenu', method: 'activate', domain: domain});
         launchVideo({url: decoded,
                      domain: domain,
                      getUrlFn: getUrlFn});


### PR DESCRIPTION
- remove `render` from `player_view` and `loading_view` in `docs/metrics.md`
- add `render` event back into `error_view`
- fix contextmenu and overlay_icon metrics events
- refs #390 (going to wait for @rayborn's approval before closing)