### PR TITLE
Increase minimized height on Linux

### DIFF
--- a/lib/panel-utils.js
+++ b/lib/panel-utils.js
@@ -79,6 +79,9 @@ const DEFAULT_DIMENSIONS = {
   width: 320,
   minimizedHeight: 40
 };
+if (system.platform === 'linux') {
+  DEFAULT_DIMENSIONS.minimizedHeight += 10;
+}
 
 const DEFAULT_PANEL_OPTIONS = {
   contentURL: './default.html?cachebust=' + Date.now(),


### PR DESCRIPTION
This should fix #427 (tested on Debian sid).

Let me know if there's a better way to fix this that doesn't involve a platform-specific check or a hard-coded 10 pixel increment (maybe there's a constant somewhere that stores the height of the small triangle on the top-left?).