### PR TITLE
add L10N support

### DIFF
--- a/.jpmignore
+++ b/.jpmignore
@@ -3,6 +3,7 @@
 !/data/**
 !/docs/images/dark-logo.png
 !/lib/**
+!/locale/**
 !/index.js
 !/install.rdf
 !/bootstrap.js

--- a/app.js
+++ b/app.js
@@ -14,7 +14,8 @@ const defaultData = {
   duration: 0,
   progress: 0.001, // force progress element to start out empty
   playing: false,
-  volume: '0.5'
+  volume: '0.5',
+  strings: {}
 };
 
 window.AppData = new Proxy(defaultData, {

--- a/components/error-view.js
+++ b/components/error-view.js
@@ -1,6 +1,5 @@
 const React = require('react');
 const cn = require('classnames');
-const ReactTooltip = require('react-tooltip');
 const sendToAddon = require('../client-lib/send-to-addon');
 const sendMetricsEvent = require('../client-lib/send-metrics-event');
 const GeneralControls = require('./general-controls');
@@ -32,17 +31,16 @@ module.exports = React.createClass({
     sendMetricsEvent('error_view', 'render');
     return (
         <div className='error' onMouseEnter={this.enterView} onMouseLeave={this.leaveView}>
-          <ReactTooltip place='bottom' effect='solid' />
           <div className={cn('controls', {hidden: !this.state.hovered, minimized: this.props.minimized})}>
             <div className='left' />
             <GeneralControls {...this.props} />
           </div>
           <div className='error-message-container'>
             <p className='error-message'>
-              Something's gone wrong with this video, Try again later.
+              {this.props.strings.errorMsg}
               <br/>
               <br/>
-              <span className='error-link' onClick={this.sendToTab}>Open in new tab</span>
+              <span className='error-link' onClick={this.sendToTab}>{this.props.strings.errorLink}</span>
             </p>
           </div>
         </div>

--- a/components/general-controls.js
+++ b/components/general-controls.js
@@ -1,10 +1,12 @@
 const React = require('react');
 const cn = require('classnames');
+const deepAssign = require('deep-assign');
 const sendToAddon = require('../client-lib/send-to-addon');
 const sendMetricsEvent = require('../client-lib/send-metrics-event');
+const ReactTooltip = require('react-tooltip');
 
 function resetPlayer() {
-  window.AppData = Object.assign(window.AppData, {
+  window.AppData = deepAssign(window.AppData, {
     error: false
   });
 }
@@ -48,12 +50,21 @@ module.exports = React.createClass({
   render: function() {
     return (
       <div className='right'>
-        <a onClick={this.sendToTab} data-tip='Send to tab' className='tab' />
+        <a onClick={this.sendToTab} data-tip data-for='sendToTab' className='tab'/>
+        <ReactTooltip id='sendToTab' effect='solid' place={!this.props.minimized ? 'bottom': 'left'}>
+          {this.props.strings.ttSendToTab}
+        </ReactTooltip>
+
         <a className={cn('minimize', {hidden: this.props.minimized})}
-          onClick={this.minimize} data-tip='Minimize' />
-        <a onClick={this.maximize} data-tip='Maximize'
-          className={cn('maximize', {hidden: !this.props.minimized})} />
-        <a className='close' onClick={this.close} data-tip='Close' />
+           onClick={this.minimize} data-tip data-for='minimize' />
+        <ReactTooltip id='minimize' effect='solid' place='left'>{this.props.strings.ttMinimize}</ReactTooltip>
+
+        <a className={cn('maximize', {hidden: !this.props.minimized})}
+           onClick={this.maximize} data-tip data-for='maximize' />
+        <ReactTooltip id='maximize' effect='solid' place='left'>{this.props.strings.ttMaximize}</ReactTooltip>
+
+        <a className='close' onClick={this.close} data-tip data-for='close' />
+        <ReactTooltip id='close' effect='solid' place='left'>{this.props.strings.ttClose}</ReactTooltip>
       </div>
     );
   }

--- a/components/loading-view.js
+++ b/components/loading-view.js
@@ -1,6 +1,5 @@
 const React = require('react');
 const cn = require('classnames');
-const ReactTooltip = require('react-tooltip');
 const GeneralControls = require('./general-controls');
 
 module.exports = React.createClass({
@@ -16,15 +15,13 @@ module.exports = React.createClass({
   render: function() {
     return (
         <div className='loading' onMouseEnter={this.enterView} onMouseLeave={this.leaveView}>
-        <ReactTooltip place='bottom' effect='solid' />
           <div className={cn('controls', {hidden: !this.state.hovered, minimized: this.props.minimized})}>
             <div className='left' />
             <GeneralControls {...this.props} />
           </div>
 
-          <img src='img/loading-bars.svg' alt='loading animation'
-              width={64} height={64} />
-          <p>Loading video from {this.props.domain}</p>
+          <img src='img/loading-bars.svg' alt='loading animation' width={64} height={64} />
+          <p>{this.props.strings.loadingMsg}</p>
         </div>
     );
   }

--- a/components/player-view.js
+++ b/components/player-view.js
@@ -1,6 +1,8 @@
 const React = require('react');
-const ReactTooltip = require('react-tooltip');
 const cn = require('classnames');
+const deepAssign = require('deep-assign');
+
+const ReactTooltip = require('react-tooltip');
 
 const ytCtrl = require('../client-lib/yt-ctrl');
 const sendMetricsEvent = require('../client-lib/send-metrics-event');
@@ -25,13 +27,13 @@ module.exports = React.createClass({
   step: function() {
     const currentTime = this.isYt ? ytCtrl.getTime() : this.refs.video.currentTime;
 
-    window.AppData = Object.assign(window.AppData, {
+    window.AppData = deepAssign(window.AppData, {
       currentTime: `${formatTime(currentTime)} / ${formatTime(window.AppData.duration)}`,
       progress: currentTime / window.AppData.duration
     });
 
     if (currentTime >= window.AppData.duration) {
-      window.AppData = Object.assign(window.AppData, {
+      window.AppData = deepAssign(window.AppData, {
         playing: false
       });
 
@@ -48,7 +50,7 @@ module.exports = React.createClass({
     // for YouTube we need to detect if the duration is 0 to see
     // if there was a problem loading.
     if (this.isYt && duration === 0) {
-      window.AppData = Object.assign(window.AppData, {error: true});
+      window.AppData = deepAssign(window.AppData, {error: true});
     }
 
     // here we store the muted prop before it gets set in the
@@ -70,7 +72,7 @@ module.exports = React.createClass({
     }
 
 
-    window.AppData = Object.assign(window.AppData, {
+    window.AppData = deepAssign(window.AppData, {
       loaded: true,
       duration: duration
     });
@@ -148,7 +150,7 @@ module.exports = React.createClass({
       this.refs.video.muted = true;
     }
 
-    window.AppData = Object.assign(window.AppData, {muted: true});
+    window.AppData = deepAssign(window.AppData, {muted: true});
   },
   clickedUnmute: function() {
     let volumeEvt = {target: {value: '0.5'}};
@@ -172,7 +174,7 @@ module.exports = React.createClass({
       this.refs.video.muted = false;
     }
 
-    window.AppData = Object.assign(window.AppData, {muted: false});
+    window.AppData = deepAssign(window.AppData, {muted: false});
   },
   setVolume: function(ev) {
     const value = parseFloat(ev.target.value);
@@ -184,7 +186,7 @@ module.exports = React.createClass({
       this.refs.video.volume = value;
     }
 
-    window.AppData = Object.assign(window.AppData, {
+    window.AppData = deepAssign(window.AppData, {
       volume: value
     });
 
@@ -208,7 +210,7 @@ module.exports = React.createClass({
 
     // if we are paused force the ui to update
     if (!this.props.playing) {
-      window.AppData = Object.assign(window.AppData, {
+      window.AppData = deepAssign(window.AppData, {
         currentTime: `${formatTime(currentTime)} / ${formatTime(window.AppData.duration)}`,
         progress: currentTime / window.AppData.duration
       });
@@ -225,7 +227,7 @@ module.exports = React.createClass({
 
     sendToAddon({action: 'close'});
     // reset error view
-    window.AppData = Object.assign(window.AppData, {
+    window.AppData = deepAssign(window.AppData, {
       error: false
     });
   },
@@ -263,19 +265,30 @@ module.exports = React.createClass({
     return (
         <div className='video-wrapper' onMouseEnter={this.enterPlayer}
              onMouseLeave={this.leavePlayer} onClick={this.handleVideoClick}>
+
           <div className={cn('controls', {hidden: !this.state.hovered, minimized: this.props.minimized})}
                onMouseEnter={this.enterControls} onMouseLeave={this.leaveControls}>
             <div className='left'>
-              <ReactTooltip place='bottom' effect='solid' />
-
-              <a onClick={this.play} data-tip='Play'
+              <a onClick={this.play} data-tip data-for='play'
                  className={cn('play', {hidden: this.props.playing})} />
-              <a onClick={this.pause} data-tip='Pause'
+              <ReactTooltip id='play' effect='solid' place='right'>{this.props.strings.ttPlay}</ReactTooltip>
+
+              <a onClick={this.pause} data-tip data-for='pause'
                  className={cn('pause', {hidden: !this.props.playing})} />
-              <a onClick={this.mute} data-tip='Mute'
+              <ReactTooltip id='pause' effect='solid' place='right'>{this.props.strings.ttPause}</ReactTooltip>
+
+              <a onClick={this.mute} data-tip data-for='mute'
                  className={cn('mute', {hidden: this.props.muted})} />
-              <a onClick={this.clickedUnmute} data-tip='Unmute'
+              <ReactTooltip id='mute' effect='solid' place={!this.props.minimized ? 'bottom': 'right'}>
+                {this.props.strings.ttMute}
+              </ReactTooltip>
+
+              <a onClick={this.clickedUnmute} data-tip data-for='unmute'
                  className={cn('unmute', {hidden: !this.props.muted})} />
+              <ReactTooltip id='unmute' effect='solid' place={!this.props.minimized ? 'bottom': 'right'}>
+                {this.props.strings.ttUnmute}
+              </ReactTooltip>
+
               <input type='range' className={cn('volume', {hidden: !this.state.showVolume})}
                      min='0' max='1' step='.01' value={this.props.muted ? 0 : this.props.volume}
                      onChange={this.setVolume}/>

--- a/data/controls.js
+++ b/data/controls.js
@@ -16,7 +16,7 @@ self.port.on('set-video', opts => {
     progress: 0,
     playing: false
   });
-  unsafeWindow.AppData = Object.assign(unsafeWindow.AppData, opts);
+  unsafeWindow.AppData = mergeDeep(unsafeWindow.AppData, opts);
 });
 
 // Bridge between app.js window messages to the
@@ -25,3 +25,26 @@ self.port.on('set-video', opts => {
 window.addEventListener('addon-message', function(ev) {
   self.port.emit('addon-message', ev.detail);
 }, false, true);
+
+/*
+ * since this file is not bundled, we cannot use the deep-assign
+ * package that we are using in the client code.
+ */
+
+function isObject(item) {
+  return (item && typeof item === 'object' && !Array.isArray(item));
+}
+
+function mergeDeep(target, source) {
+  if (isObject(target) && isObject(source)) {
+    for (const key in source) {
+      if (isObject(source[key])) {
+        if (!target[key]) Object.assign(target, { [key]: {} });
+        mergeDeep(target[key], source[key]);
+      } else {
+        Object.assign(target, { [key]: source[key] });
+      }
+    }
+  }
+  return target;
+}

--- a/data/default.html
+++ b/data/default.html
@@ -6,17 +6,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>MIN VID PANEL</title>
     <link rel="stylesheet" href="panel.css" type="text/css" media="screen" />
-
-    <!-- uncomment for manual testing of ui in browser without addon reload loop -->
-    <!-- <style> -->
-    <!--   #container { -->
-    <!--     width: 320px !important; -->
-    <!--     height: 180px !important; -->
-    <!--     border: 1px solid pink; -->
-    <!--   } -->
-    <!-- </style> -->
   </head>
   <body>
     <div id="container"></div>

--- a/lib/get-locale-strings.js
+++ b/lib/get-locale-strings.js
@@ -1,0 +1,17 @@
+const _ = require('sdk/l10n').get;
+
+module.exports = function(domain) {
+  return {
+    errorMsg: _('error_msg'),
+    errorLink: _('error_link'),
+    loadingMsg: _('loading_msg', domain),
+    ttMute: _('tooltip_mute'),
+    ttPlay: _('tooltip_play'),
+    ttPause: _('tooltip_pause'),
+    ttClose: _('tooltip_close'),
+    ttUnmute: _('tooltip_unmute'),
+    ttMinimize: _('tooltip_minimize'),
+    ttMaximize: _('tooltip_maximize'),
+    ttSendToTab: _('tooltip_send_to_tab')
+  };
+}

--- a/lib/launch-video.js
+++ b/lib/launch-video.js
@@ -1,5 +1,6 @@
 const getVideoId = require('get-video-id');
 const panelUtils = require('./panel-utils');
+const getLocaleStrings = require('./get-locale-strings');
 
 module.exports = launchVideo;
 
@@ -21,7 +22,8 @@ function launchVideo(opts) {
       id: id,
       src: opts.src || '',
       volume: opts.volume,
-      muted: opts.muted
+      muted: opts.muted,
+      strings: getLocaleStrings(opts.domain)
     });
     panel.show();
     panelUtils.redraw(true);
@@ -32,7 +34,10 @@ function launchVideo(opts) {
         const panel = panelUtils.getPanel();
         if (err) console.error('LaunchVideo failed to get the streamUrl: ', err); // eslint-disable-line no-console
         if (!panel) return console.error('LaunchVideo lost the panel while waiting for the streamUrl.'); // eslint-disable-line no-console
-        panel.port.emit('set-video', {src: streamUrl, error: Boolean(err)});
+        panel.port.emit('set-video', {
+          src: streamUrl, error: Boolean(err),
+          strings: getLocaleStrings(opts.domain)
+        });
         panel.show();
         panelUtils.redraw(true);
       }, opts.time);

--- a/lib/panel-utils.js
+++ b/lib/panel-utils.js
@@ -14,6 +14,7 @@ const makePanelDraggable = require('./make-panel-draggable.js');
 const simpleStorage = require('sdk/simple-storage');
 const { setTimeout } = require('sdk/timers');
 const { Cu } = require('chrome');
+const getLocaleStrings = require('./get-locale-strings');
 Cu.import('resource://gre/modules/Services.jsm');
 
 // panel utils:
@@ -307,12 +308,21 @@ function messageHandler(opts) {
     if (pageUrl) require('sdk/tabs').open(pageUrl);
     else {
       console.error('could not parse page url for ', opts); // eslint-disable-line no-console
-      panel.port.emit('set-video', {error: 'Error loading video from ' + opts.domain});
+      panel.port.emit('set-video', {
+        error: 'Error loading video from ' + opts.domain,
+        strings: getLocaleStrings(opts.domain)
+      });
     }
-    panel.port.emit('set-video', {domain: '', src: ''});
+    panel.port.emit('set-video', {
+      domain: '', src: '',
+      strings: getLocaleStrings(opts.domain)
+    });
     panel.hide();
   } else if (title === 'close') {
-    panel.port.emit('set-video', {domain: '', src: ''});
+    panel.port.emit('set-video', {
+      domain: '', src: '',
+      strings: getLocaleStrings(opts.domain)
+    });
     panel.hide();
   } else if (title === 'minimize') {
     minimize();

--- a/locale/en-US.properties
+++ b/locale/en-US.properties
@@ -1,0 +1,12 @@
+tooltip_play= Play
+tooltip_pause= Pause
+tooltip_mute= Mute
+tooltip_unmute= Unmute
+tooltip_send_to_tab= Send to tab
+tooltip_minimize= Minimize
+tooltip_maximize= Maximize
+tooltip_close= Close
+error_msg= Something's gone wrong with this video. Try again later.
+error_link= Open in new tab
+# LOCALIZATION NOTE: placeholder is domain name
+loading_msg= Loading video from %s

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "firefox": ">=38.0a1"
   },
   "permissions": {
-    "multiprocess": true
+    "multiprocess": true,
+    "unsafe-content-script": true
   },
   "bugs": {
     "url": "https://github.com/meandavejustice/min-vid/issues"
@@ -44,6 +45,7 @@
     "babelify": "7.3.0",
     "browserify": "13.0.1",
     "classnames": "2.2.5",
+    "deep-assign": "2.0.0",
     "eslint": "3.6.1",
     "eslint-plugin-react": "6.3.0",
     "http-server": "0.9.0",


### PR DESCRIPTION
- fixes #441
- fixes #110
- refs #113 got rid of some warnings, still being caused in
general-controls component
- add `locales/en-US.properties`
- add `lib/locale-strings.js` for mapping keys to strings
- add `client-lib/merge-deep.js` as a deep clone replacement for
`Object.assign`
- update all strings to use localized strings
- switched to using "data-for" syntax with `react-tooltip`. This
allows for us to pass in the localized strings without issues
and also silences some of the warnings mentioned in #113
- removed excess `<style>` tag in data/default.html

#### note
had to add `unsafe-content-script` permission in order to
 store a "strings" object on unsafeWindow.AppData. I think this is
okay for now, it's not causing any issues with e10s on my machine.
I'm planning to rework the way we are handling data updates one
day, so it should be fine for now.