### PR TITLE
Only fire one metrics event per error

### DIFF
--- a/components/error-view.js
+++ b/components/error-view.js
@@ -28,8 +28,10 @@ module.exports = React.createClass({
       tabId: this.props.tabId
     });
   },
-  render: function() {
+  componentWillMount: function() {
     sendMetricsEvent('error_view', 'render');
+  },
+  render: function() {
     return (
         <div className='error' onMouseEnter={this.enterView} onMouseLeave={this.leaveView}>
           <div className={cn('controls', 'drag', {hidden: !this.state.hovered, minimized: this.props.minimized})}>


### PR DESCRIPTION
Fixes #496.

Sending metrics pings from inside the render method caused a lot of duplicate errors to be fired.