### PR TITLE
POC: use swapBrowsers and fullscreen machinery for the mini-window

### DIFF
--- a/data/icon-overlay.js
+++ b/data/icon-overlay.js
@@ -78,6 +78,7 @@ function ytHomePageHandler(el) {
   const tmp = getTemplate();
   tmp.addEventListener('click', function(ev) {
     evNoop(ev);
+
     self.port.emit('launch', {
       url: 'https://youtube.com' + url,
       domain: 'youtube.com'
@@ -94,8 +95,8 @@ function ytWatchElementHandler(el) {
   tmp.addEventListener('click', function(ev) {
     evNoop(ev);
     const videoEl = document.querySelector('video');
-    videoEl.pause();
     closeFullscreen();
+    //videoEl.pause(); // no need to pause the video, since it continues playing in the new window.
     self.port.emit('launch', {
       url: window.location.href,
       domain: 'youtube.com',

--- a/lib/window-utils.js
+++ b/lib/window-utils.js
@@ -28,21 +28,51 @@ let commandPollTimer;
 // waits till the window is ready, then calls callbacks.
 function whenReady(cb) {
   // TODO: instead of setting timeout for each callback, just poll, then call all callbacks.
+  if (mvWindow && mvWindow.gBrowserInit && mvWindow.gBrowserInit.delayedStartupFinished) return cb();
+  /*
   if (mvWindow &&
       'AppData' in mvWindow.wrappedJSObject &&
       'YT' in mvWindow.wrappedJSObject &&
       'PlayerState' in mvWindow.wrappedJSObject.YT) return cb();
+  */
   setTimeout(() => { whenReady(cb) }, 25);
 }
 
 // I can't get frame scripts working, so instead we just set global state directly in react. fml
 function send(eventName, msg) {
   whenReady(() => {
+    if (eventName === 'set-video') {
+      // TBD: this is called twice for some reason
+
+      // instead of making the window widget full-screen, just make the video
+      // element cover the whole window when fullscreen is requested
+      Services.prefs.setBoolPref("full-screen-api.ignore-widgets", true);
+
+      // request fullscreen from the context of the page, but with chrome
+      // privileges -- to avoid the restriction that fullscreen must be
+      // requested directly in response to user action.
+      var mm = mvWindow.gBrowser.selectedBrowser.messageManager;
+
+      // don't show the 'is now full screen' message
+      mvWindow.document.getElementById('fullscreen-warning').style.visibility = 'hidden';
+
+      mm.loadFrameScript(`data:,
+        dump("framescript5\\n");
+        content.document.querySelector('video').requestFullscreen();
+        addEventListener('fullscreenchange', function() {
+          dump("on full screen change");
+        });
+      `, false); // <-- aAllowDelayedLoad
+      //TBD unset the pref after successfully triggering fullscreen (or bail and close the window in case of something goes wrong)
+      // Services.prefs.setBoolPref("full-screen-api.ignore-widgets", false);
+    }
+    /* TBD: this requires need new UI
     const newData = Object.assign(mvWindow.wrappedJSObject.AppData, msg);
     mvWindow.wrappedJSObject.AppData = newData;
+    */
   });
 }
-
+dump("load");
 function getWindow() {
   return mvWindow;
 }
@@ -83,10 +113,17 @@ function create() {
   if (mvWindow) return mvWindow;
 
   const window = getMostRecentBrowserWindow();
+
+  // create a tab so that we have a tab left in the original window
+  // (swapBrowsers won't leave the donor tabbrowser empty)
+  // Perhaps this tab could allow the user to send the video back to the page?
+  let mvBackupTab = window.gBrowser.addTab();
   const { x, y } = saveLocation.screenPosition;
-  const windowArgs = `left=${x},top=${y},chrome,dialog=no,width=320,height=180,titlebar=no`;
+  // TBD: this size is persisted for new browser windows
+  const windowArgs = `left=${x},top=${y},width=320,height=180,titlebar=no`;
   // implicit assignment to mvWindow global
-  mvWindow = window.open(self.data.url('default.html'), 'minvid', windowArgs);
+  mvWindow = window.openDialog("chrome://browser/content/", "_blank", "chrome,dialog=no,all" + windowArgs, window.gBrowser.mCurrentTab);
+  //mvWindow = window.open(self.data.url('default.html'), 'minvid', windowArgs);
   // once the window's ready, make it always topmost
   whenReady(() => { topify(mvWindow); });
   initCommunication();
@@ -102,7 +139,7 @@ function initCommunication() {
     try {
       cmd = mvWindow.wrappedJSObject.pendingCommands;
     } catch (ex) {
-      console.error('something happened trying to get pendingCommands: ', ex); // eslint-disable-line no-console 
+      console.error('something happened trying to get pendingCommands: ', ex); // eslint-disable-line no-console
       if (++errorCount > 10) {
         console.error('pendingCommands threw 10 times, giving up');            // eslint-disable-line no-console
         // NOTE: if we can't communicate with the window, we have to close it,


### PR DESCRIPTION
This is a proof-of-concept for an alternative implementation of the mini-player that could be used to solve #331. I don't know if this has been considered before (sorry if it has).

The basic idea is that instead of trying to rip the video out its host page and display in a separate floating window, we could instead
* move the whole page to a separate window (just like "Move to New Window" in the tab strip's context menu does)
* and then make the video -- but not the mini-player window -- "fullscreen".

The latter can be achieved using a preference made for the B2G emulator.

This removes the delay when switching to minivid and any kind of HTML5 video (that can play full-screen) can play in the mini-player, including EME-protected videos (Netflix), which even captureStream (discussed in #331) will not handle.

I used browser.xul in this PoC, but a real implementation could use simpler chrome with just a xul:browser. It's a massive amount of work, but I think it's worth the result.

What do you think?

(To check this out, open a YouTube video, then click the minivid overlay -- all other functionality, including the UI is not implemented. I tested on the current Nightly)