### PR TITLE
Update visual feedback for history '+' button.

### DIFF
--- a/components/queues.js
+++ b/components/queues.js
@@ -66,7 +66,7 @@ class QueuesView extends React.Component {
             <ReactTooltip id='collapse-queue-menu' effect='solid' place='left'>{this.props.strings.ttCloseQueue}</ReactTooltip>
           </header>
 
-          <TabPanel className='panel-wrapper'>
+          <TabPanel className='panel-wrapper panel-queue'>
             <div className='clear'><a onClick={this.clearQueue.bind(this)}>{this.props.strings.clear}</a></div>
             <ul ref={this.sortableContainersDecorator.bind(this)}>
             {this.props.queue.map((item, i) => <Item {...item} shouldDrag={true} index={i} audio={this.props.audio}
@@ -74,7 +74,7 @@ class QueuesView extends React.Component {
             </ul>
           </TabPanel>
 
-          <TabPanel className='panel-wrapper'>
+          <TabPanel className='panel-wrapper panel-history'>
           <div className='clear'><a onClick={this.clearHistory.bind(this)}>{this.props.strings.clear}</a></div>
             <ul ref={this.sortableContainersDecorator}>
             {this.props.history.map((item, i) => <Item {...item} key={this.state.keyPrefix + i} index={i} replay={this.props.replay} isHistory={true} />)}

--- a/data/panel.css
+++ b/data/panel.css
@@ -534,12 +534,16 @@ canvas {
     width: 100%;
 }
 
-.queues .panel-wrapper li:first-child {
+.queues .panel-wrapper.panel-queue li:first-child {
     background: #363636;
 }
 
 .queues .panel-wrapper li:hover {
     background: #4a4a4a;
+}
+
+.queues .panel-wrapper.panel-history li:hover .add-from-history{
+    opacity: .7;
 }
 
 .queues .panel-wrapper li h5 {
@@ -789,6 +793,11 @@ canvas {
 
 .add-from-history {
     cursor: pointer;
+    opacity: .2;
+}
+
+.add-from-history:hover {
+    opacity: 1 !important;
 }
 
 .notification {


### PR DESCRIPTION
A few visual updates:
- Add hover state for '+' button in the history panel.
- Remove highlighting the first item in the history panel (we only need to highlight the currently playing item in the queue panel)

Like this:
![apr-26-2017 13-05-22](https://cloud.githubusercontent.com/assets/8919308/25419026/8153a1c6-2a82-11e7-8348-87170f07c736.gif)
