### PR TITLE
Clean up play button behavior when last item exits

### DIFF
--- a/components/playback-control.js
+++ b/components/playback-control.js
@@ -5,7 +5,9 @@ const sendMetricsEvent = require('../client-lib/send-metrics-event');
 
 module.exports = class PlaybackControl extends React.Component {
   play() {
-    // TODO: Handle replay
+    if (this.props.exited) {
+      return this.props.replay();
+    }
     sendMetricsEvent('player_view', 'play');
     if (this.props.audio) this.props.audio.play();
     window.AppData.set({playing: true});

--- a/components/player-view.js
+++ b/components/player-view.js
@@ -105,7 +105,7 @@ module.exports = class Player extends React.Component {
 
   onEnded() {
     if (this.props.queue.length === 1) {
-      window.AppData.set({exited: true});
+      window.AppData.set({exited: true, playing: false});
     } else sendToAddon({action: 'track-ended'});
   }
 
@@ -284,9 +284,9 @@ module.exports = class Player extends React.Component {
                                               openQueueMenu={this.openQueueMenu.bind(this)} />
                                               <PlayerControls {...this.props} hovered={this.state.hovered} progress={this.state.progress}
                                               audio={this.audio} time={this.state.time} setTime={this.setTime.bind(this)}
-                                              closeQueueMenu={this.closeQueueMenu.bind(this)} />
+                                              replay={this.replay.bind(this)} closeQueueMenu={this.closeQueueMenu.bind(this)} />
                                               </div>) : (<MinimizedControls {...this.props} progress={this.state.progress}
-                                                         time={this.state.time} setTime={this.setTime.bind(this)} />);
+                                                         replay={this.replay.bind(this)} time={this.state.time} setTime={this.setTime.bind(this)} />);
 
     return (<div className='video-wrapper'
                  onMouseEnter={this.enterPlayer.bind(this)}

--- a/lib/window-utils.js
+++ b/lib/window-utils.js
@@ -203,11 +203,13 @@ function handleMessage(msg) {
     sendMetricsData(opts.payload, mvWindow);
   } else if (title === 'track-ended') {
     store.history.unshift(store.queue.shift());
-    send('set-video', {
-      playing: true,
-      queue: JSON.stringify(store.queue),
-      history: JSON.stringify(store.history)
-    });
+    if (store.queue.length) {
+      send('set-video', {
+        playing: true,
+        queue: JSON.stringify(store.queue),
+        history: JSON.stringify(store.history)
+      });
+    }
   } else if (title === 'track-removed') {
     if (opts.isHistory) store.history.splice(opts.index, 1);
     else store.queue.splice(opts.index, 1);


### PR DESCRIPTION
* Toggle the play/pause button when a video ends

* If play is pressed when exited is true, then replay

Fixes #782.

-----

I verified that this fixes the issues mentioned in #782. Ran into some weirdness with the replay button getting youtube videos into the choppy state where it's manically flipping between play and pause, but I also saw that bug without this patch applied, so hopefully that's a known thing.