### PR TITLE
Fix #832 & #833

### DIFF
--- a/data/panel.css
+++ b/data/panel.css
@@ -293,7 +293,7 @@ video#video {
     display: flex;
     width: 100%;
     height: 50px;
-    background: #222222;
+    background: #2a2a2a;
     opacity: 1;
 }
 
@@ -404,6 +404,7 @@ input[type=range]::-moz-focus-outer {
     position: absolute;
     bottom: 20px;
     left: 35px;
+    background: none;
 }
 
 .minimized .volume input {
@@ -726,7 +727,7 @@ canvas {
 }
 
 .minimized .sound-control {
-    margin-right: 79px;
+    margin-right: 73px;
 }
 
 .collapse-queue {
@@ -849,14 +850,17 @@ canvas {
 
 .notification {
     position: absolute;
-    bottom: 25%;
-    left: 32%;
-    right: 32%;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: auto;
+    width: 130px;
+    height: 16px;
     background: #000000b3;
     color: white;
-    border-radius: 4px;
+    border-radius: 12px;
     padding: 5px;
-
     font-size: 12px;
     opacity: 0;
 }


### PR DESCRIPTION
#833 change the bottom-control background color to differentiate from tooltip color.
#832 modify the "item added to queue" position to the center of the minvid player.

#833
<img width="394" alt="screen shot 2017-05-12 at 3 19 44 pm" src="https://cloud.githubusercontent.com/assets/8919308/25987474/bf886746-3726-11e7-8bf6-bdec7ce85d25.png">

#832
<img width="397" alt="screen shot 2017-05-12 at 3 20 25 pm" src="https://cloud.githubusercontent.com/assets/8919308/25987481/c3d9137c-3726-11e7-992d-0e41cf3af47a.png">
<img width="399" alt="screen shot 2017-05-12 at 3 20 32 pm" src="https://cloud.githubusercontent.com/assets/8919308/25987485/c8600252-3726-11e7-964a-755c17196a45.png">
