### PR TITLE
Update non breaking dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "license": "MPL-2.0",
   "devDependencies": {
-    "addons-linter": "0.20.0",
+    "addons-linter": "0.22.8",
     "audiosource": "3.0.3",
     "babel": "6.23.0",
     "babel-core": "6.25.0",
@@ -39,10 +39,11 @@
     "deep-assign": "2.0.0",
     "deploy-txp": "1.0.7",
     "eslint": "3.19.0",
-    "eslint-plugin-mozilla": "0.3.2",
-    "eslint-plugin-react": "7.0.1",
+    "eslint-plugin-mozilla": "0.4.2",
+    "eslint-plugin-no-unsanitized": "2.0.1",
+    "eslint-plugin-react": "7.2.1",
     "get-video-id": "2.1.5",
-    "husky": "0.13.4",
+    "husky": "0.14.3",
     "iso8601-duration": "1.0.6",
     "keyboardjs": "2.3.3",
     "lodash.debounce": "4.0.8",
@@ -50,12 +51,12 @@
     "pontoon-to-webext": "1.0.2",
     "react": "15.6.1",
     "react-dom": "15.6.1",
-    "react-player": "0.19.1",
+    "react-player": "0.20.0",
     "react-tabs": "0.8.3",
     "react-tooltip": "3.3.0",
     "sortablejs": "1.6.0",
     "testpilot-ga": "0.3.0",
     "uuid": "3.1.0",
-    "webpack": "3.3.0"
+    "webpack": "3.5.4"
   }
 }


### PR DESCRIPTION
- addons-linter
- eslint-plugin-mozilla
- eslint-plugin-react
- husky
- react-player
- webpack

Also needed to add a new dep:
- eslint-no-unsanitized

Looks like this is a dep of eslint-plugin-mozilla that isn't listed correctly in the
eslint-plugin-mozilla package. This package is for some reason bundled in with gecko
so I do not have the time to contribute a fix at this time. Hopefully I will find
the time later.