### PR TITLE
Slightly better replay handling in minimized mode

### DIFF
--- a/frontend/components/playback-control.js
+++ b/frontend/components/playback-control.js
@@ -7,7 +7,9 @@ import sendMetricsEvent from '../client-lib/send-metrics-event';
 export default class PlaybackControl extends React.Component {
   play() {
     if (this.props.exited) {
-      return this.props.replay();
+      sendMetricsEvent('player_view', 'replay', '');
+      this.props.replay();
+      return;
     }
     if (this.props.audio) {
       this.props.audio.play();

--- a/frontend/components/replay-view.js
+++ b/frontend/components/replay-view.js
@@ -4,6 +4,13 @@ import sendToAddon from '../client-lib/send-to-addon';
 import sendMetricsEvent from '../client-lib/send-metrics-event';
 
 export default class ReplayView extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      hasSetInitialPlayerState: false
+    };
+  }
+
   close() {
     sendMetricsEvent('replay_view', 'close', this.props.queue[0].domain);
     sendToAddon({action: 'close'});
@@ -27,6 +34,14 @@ export default class ReplayView extends React.Component {
     };
 
     if (!this.props.exited) return;
+
+    // only set playing to false once, on initial load, otherwise
+    // we end up in an ugly loop!
+    if (!this.state.hasSetInitialPlayerState && this.props.exited) {
+      this.setState({hasSetInitialPlayerState: true});
+      window.AppData.set({playing: false});
+    }
+
     interval();
   }
 


### PR DESCRIPTION
- refs #999
- We now set the player state to not playing so that the user can
select the play button in minimized mode in order to replay the
video. This is still not how it should be, not a complete fix, but
an improvement none the less. New behavior is: Click play button in
minimized view when the video is in "exited" state (replay view
showing in maximized view) the video is reset to the beginning of
playback, however the video is still paused at this point, so it
actually requires two clicks to get the desired re-playback. I plan
to revisit this in the next update (or within this one if I have
the time.