### PR TITLE
Fix metrics logging for pause event

### DIFF
--- a/frontend/components/player-view.js
+++ b/frontend/components/player-view.js
@@ -93,7 +93,7 @@ export default class Player extends React.Component {
   }
 
   onPause() {
-    sendMetricsEvent('player_view', 'pause'), this.props.queue[0].domain;
+    sendMetricsEvent('player_view', 'pause', this.props.queue[0].domain);
     window.AppData.set({playing: false});
   }
 


### PR DESCRIPTION
Hi! I came across a small error while browsing the code, thought a fix might save some confusion for the people looking at analytics data :smile:

EDIT: I guess eslint would have caught this, but `no-unused-expressions` is disabled in [the configuration](https://github.com/meandavejustice/min-vid/blob/master/.eslintrc.json#L44). You may want to consider enabling it, depending on false positive rate.