### PR TITLE
satisfy 'study setup' schema

### DIFF
--- a/Config.jsm
+++ b/Config.jsm
@@ -2,6 +2,10 @@
 const EXPORTED_SYMBOLS = ["config"];
 
 const config = {
+  addon: {
+    id: "@min-vid-study",
+    version: "0.4.5-study"
+  },
   study: {
     studyName: "min-vid-study", // no spaces, for all the reasons
     /** **endings**


### PR DESCRIPTION
looks like the 'addon' key is required. see also https://gist.github.com/6a68/8412b6af9e4fca35bd5ebad6baa494d8 and https://github.com/gregglind/shield-study-schemas/issues/2