### PR TITLE
Shield variations

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -20,7 +20,6 @@
     <em:description>Minimize a web video or audio track into a small always-on-top panel in Firefox.</em:description>
     <em:homepageURL>https://testpilot.firefox.com/experiments/min-vid</em:homepageURL>
     <em:iconURL>chrome://minvid-skin/content/icon.png</em:iconURL>
-    <em:optionsType>2</em:optionsType>
     <em:updateURL>https://testpilot.firefox.com/files/@min-vid/updates.json</em:updateURL>
     <em:targetApplication>
       <Description>


### PR DESCRIPTION
Things in this pull request:
- update eligibility check to exclude existing min-vid installs
- randomly pick between three variations (inactive, active, activeAndOnboarding), set the value as a pref which is removed at uninstall
- allow QA to override the variations via a separate pref
  - but note that the variations can't be changed restartlessly. I could add this but didn't see it in the [pioneer enrollment study](https://github.com/mozilla/pioneer-enrollment-study/blob/a8703aca37c04d903782cd4bac2d5fd41616e522/extension/bootstrap.js#L240-L265), so maybe it's not needed
- don't start the webextension if the 'inactive' variation is picked, otherwise start minvid as usual

Still need to do something special for the activeAndOnboarding variation.