### PR TITLE
Remove obsolete 'conditional catch' statement from ostypes code

### DIFF
--- a/lib/vendor/noitidart-ostypes/cutils.jsm
+++ b/lib/vendor/noitidart-ostypes/cutils.jsm
@@ -193,9 +193,15 @@ function utilsInit() {
 				var char8_val = stringPtr.readString();
 				//console.info('stringPtr.readString():', char8_val);
 				return char8_val;
-			} catch (ex if ex.message.indexOf('malformed UTF-8 character sequence at offset ') == 0) {
-				//console.warn('ex of offset utf8 read error when trying to do readString so using alternative method, ex:', ex);
-				return readJSCharString();
+			// NOTE: updated to adjust for removal of conditional catch from firefox implementation of JS in bug 1228841.
+			// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch#Conditional_catch_clauses
+			//
+			} catch (ex) {
+				if (ex.message.indexOf('malformed UTF-8 character sequence at offset ') == 0) {
+					//console.warn('ex of offset utf8 read error when trying to do readString so using alternative method, ex:', ex);
+					return readJSCharString();
+				}
+				throw ex;
 			}
 		} else {
 			return readJSCharString();


### PR DESCRIPTION
Fixes #1145.

Looks weird, but I decided to just stick with tabs, not spaces, as the upstream file does.

Haven't tested this fix myself, but this is the only instance of a conditional catch I've seen in the codebase. 