### PR TITLE
Check the correct pref to detect if Telemetry is enabled

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -19,7 +19,7 @@ XPCOMUtils.defineLazyModuleGetter(this, 'TelemetryController',
                                   'resource://gre/modules/TelemetryController.jsm');
 let currentVariation;
 
-const TELEMETRY_ENABLED_PREF = 'testpilot.backup.toolkit.telemetry.enabled';
+const TELEMETRY_ENABLED_PREF = 'datareporting.healthreport.uploadEnabled';
 
 // Config.jsm, inlined
 const config = {


### PR DESCRIPTION
Did a quick `git bisect`, landed on commit 337d69f, which uses the wrong pref to check if telemetry is enabled.

Inserting the correct pref fixes #1165 and fixes #1174.