### PR TITLE
Detect shield env var

### DIFF
--- a/webextension/lib/send-metrics-data.js
+++ b/webextension/lib/send-metrics-data.js
@@ -1,5 +1,5 @@
 const TestPilotGA = require('testpilot-ga');
-const isShieldStudy = (process.env.IS_SHIELD_STUDY === 'true');
+const isShieldStudy = (process.env.IS_SHIELD_STUDY === true);
 let analytics;
 
 if (!isShieldStudy) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,7 @@ module.exports = [
         }
       ]
     },
+    plugins,
     entry: './webextension/background.js',
     output: {
       filename: './webextension/dist/background.bundle.js'


### PR DESCRIPTION
* Pass IS_SHIELD_STUDY env var to the addon build chain

* Check for a boolean, not a string, as that's what webpack seems to pass in

Fixes #1206