### PR TITLE
Focus the tab opened by StudyUtils when the shield study ends

### DIFF
--- a/lib/StudyUtils.jsm
+++ b/lib/StudyUtils.jsm
@@ -360,7 +360,9 @@ class StudyUtils {
       // Wait for the window to be opened
       await new Promise(resolve => setTimeout(resolve, 30000));
     }
-    Services.wm.getMostRecentWindow("navigator:browser").gBrowser.addTab(url, params);
+    var tabbrowser = Services.wm.getMostRecentWindow("navigator:browser").gBrowser;
+    var newTab = tabbrowser.addTab(url, params);
+    tabbrowser.selectedTab = newTab;
   }
   async getTelemetryId() {
     return await getTelemetryId(); // eslint-disable-line no-return-await


### PR DESCRIPTION
This is a bug in upstream code, but it's pretty straightforward XPCOM tab juggling.

The snippet I inserted comes [from MDN](https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Tabbed_browser), actually.

Fixes #1182.