### PR TITLE
Consolidate getView function into own method and add detection for

### DIFF
--- a/frontend/client-lib/get-view.js
+++ b/frontend/client-lib/get-view.js
@@ -1,0 +1,5 @@
+export default function getView() {
+  if (window.AppData.error) return 'error_view';
+  if (window.AppData.exited) return 'replay_view';
+  return window.AppData.loaded ? 'player_view' : 'loading_view';
+}

--- a/frontend/components/close-control.js
+++ b/frontend/components/close-control.js
@@ -2,11 +2,7 @@ import React from 'react';
 import ReactTooltip from 'react-tooltip';
 import sendMetricsEvent from '../client-lib/send-metrics-event';
 import sendToAddon from '../client-lib/send-to-addon';
-
-function getView() {
-  if (window.AppData.error) return 'error_view';
-  return window.AppData.loaded ? 'player_view' : 'loading_view';
-}
+import getView from '../client-lib/get-view';
 
 export default class Close extends React.Component {
   close() {

--- a/frontend/components/send-to-tab.js
+++ b/frontend/components/send-to-tab.js
@@ -2,11 +2,7 @@ import React from 'react';
 import ReactTooltip from 'react-tooltip';
 import sendToAddon from '../client-lib/send-to-addon';
 import sendMetricsEvent from '../client-lib/send-metrics-event';
-
-function getView() {
-  if (window.AppData.error) return 'error_view';
-  return window.AppData.loaded ? 'player_view' : 'loading_view';
-}
+import getView from '../client-lib/get-view';
 
 export default class SendToTab extends React.Component {
   sendToTab() {

--- a/frontend/components/size-control.js
+++ b/frontend/components/size-control.js
@@ -4,11 +4,7 @@ import keyboardJS from 'keyboardjs';
 import ReactTooltip from 'react-tooltip';
 import sendMetricsEvent from '../client-lib/send-metrics-event';
 import sendToAddon from '../client-lib/send-to-addon';
-
-function getView() {
-  if (window.AppData.error) return 'error_view';
-  return window.AppData.loaded ? 'player_view' : 'loading_view';
-}
+import getView from '../client-lib/get-view';
 
 export default class SizeControl extends React.Component {
   componentDidMount() {

--- a/frontend/components/sound-control.js
+++ b/frontend/components/sound-control.js
@@ -3,6 +3,7 @@ import cn from 'classnames';
 import keyboardJS from 'keyboardjs';
 import ReactTooltip from 'react-tooltip';
 import sendMetricsEvent from '../client-lib/send-metrics-event';
+import getView from '../client-lib/get-view';
 
 export default class SoundControl extends React.Component {
   constructor(props) {
@@ -48,7 +49,7 @@ export default class SoundControl extends React.Component {
 
   mute() {
     const domain = this.props.queue.length ? this.props.queue[0].domain : null;
-    sendMetricsEvent('player_view', 'mute', domain);
+    if (getView() !== 'error_view') sendMetricsEvent(getView(), 'mute', domain);
     this.setState({prevVolume: this.props.volume});
     if (this.props.audio) this.props.audio.mute();
     window.AppData.set({muted: true, volume: 0});
@@ -56,7 +57,7 @@ export default class SoundControl extends React.Component {
 
   unmute() {
     const domain = this.props.queue.length ? this.props.queue[0].domain : null;
-    sendMetricsEvent('player_view', 'unmute', domain);
+    if (getView() !== 'error_view') sendMetricsEvent(getView(), 'unmute', domain);
     if (this.props.audio) this.props.audio.unmute();
     window.AppData.set({muted: false, volume: this.state.prevVolume});
   }


### PR DESCRIPTION
Consolidate getView function into own method and add detection for exited view.

Also exit early for mute/unmute events in error view.

- fixes #1250
- fixes #1249
- fixes #1246
- fixes #1245