### PR TITLE
Update placeholders in loading_view_msg

### DIFF
--- a/locales/bn-BD/addon.properties
+++ b/locales/bn-BD/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= সারিতে আর কোন আইটেম নেই
 error_msg= ভিডিওতে ত্রুটি রয়েছে। পরে আবার চেষ্টা করুন।
 error_link= নতুন ট্যাবে খুলুন
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= লোডিং %s থেকে %s
+loading_view_msg= লোডিং $1 থেকে $2
 
 confirm_msg= আপনি কি করতে পছন্দ করবেন?
 add_confirm_msg= যোগ

--- a/locales/de/addon.properties
+++ b/locales/de/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= Die Warteschlange enthält keine weiteren Elemente
 error_msg= Bei diesem Video ist ein Fehler aufgetreten. Versuchen Sie es später erneut.
 error_link= In neuem Tab öffnen
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= %s von %s wird geladen
+loading_view_msg= $1 von $2 wird geladen
 
 confirm_msg= Was möchten Sie tun?
 add_confirm_msg= Hinzufügen

--- a/locales/el/addon.properties
+++ b/locales/el/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= Δεν υπάρχουν άλλα στοιχεία στην ουρ�
 error_msg= Κάτι πήγε στραβά με αυτό το βίντεο. Δοκιμάστε ξανά αργότερα.
 error_link= Άνοιγμα σε νέα καρτέλα
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= Φόρτωση %s από %s
+loading_view_msg= Φόρτωση $1 από $2
 
 confirm_msg= Τι θα θέλατε να κάνετε;
 add_confirm_msg= Προσθήκη

--- a/locales/es-CL/addon.properties
+++ b/locales/es-CL/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= No quedan elementos para añadir a la cola
 error_msg= Algo está mal con este video. Vuelve a intentarlo más tarde.
 error_link= Abrir en nueva pestaña
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= Cargando %s desde %s
+loading_view_msg= Cargando $1 desde $2
 
 confirm_msg= ¿Qué quieres hacer?
 add_confirm_msg= Añadir

--- a/locales/es-ES/addon.properties
+++ b/locales/es-ES/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= No hay más elementos en la cola
 error_msg= Hubo un error con el vídeo. Vuelve a intentarlo más tarde.
 error_link= Abrir en nueva pestaña
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= Cargando %s desde %s
+loading_view_msg= Cargando $1 desde $2
 
 confirm_msg= ¿Qué quieres hacer?
 add_confirm_msg= Agregar

--- a/locales/es-MX/addon.properties
+++ b/locales/es-MX/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= No hay elementos en la cola
 error_msg= Algo está mal con este video. Intenta de nuevo más tarde.
 error_link= Abrir en una nueva pestaña
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= Cargando %s desde %s
+loading_view_msg= Cargando $1 desde $2
 
 confirm_msg= ¿Qué te gustaría hacer?
 add_confirm_msg= Agregar

--- a/locales/fy-NL/addon.properties
+++ b/locales/fy-NL/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= Der binne gjin items mear yn de wachtrige
 error_msg= Der is wat mis gien mei dizze fideo. Probearje letter nochris.
 error_link= Iepenje yn nij ljepblêd
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= %s lade fan %s ôf
+loading_view_msg= $1 lade fan $2 ôf
 
 confirm_msg= Wat wolle jo dwaan?
 add_confirm_msg= Tafoegje

--- a/locales/hu/addon.properties
+++ b/locales/hu/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= Nincs több elem a sorban
 error_msg= Hiba történt ezzel a videóval. Próbálkozzon később.
 error_link= Megnyitás új lapon
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= %s betöltése innen: %s
+loading_view_msg= $1 betöltése innen: $2
 
 confirm_msg= Mit szeretne tenni?
 add_confirm_msg= Hozzáadás

--- a/locales/id/addon.properties
+++ b/locales/id/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= Tidak ada item lain dalam antrian
 error_msg= Terjadi kesalahan pada video ini. Coba lagi nanti.
 error_link= Buka di tab baru
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= Memuat %s dari %s
+loading_view_msg= Memuat $1 dari $2
 
 confirm_msg= Apa yang ingin Anda lakukan?
 add_confirm_msg= Tambahkan

--- a/locales/it/addon.properties
+++ b/locales/it/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= Non ci sono elementi in coda
 error_msg= Si è verificato un problema con questo video. Riprova più tardi.
 error_link= Apri in una nuova scheda
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= Caricamento %s da %s
+loading_view_msg= Caricamento $1 da $2
 
 confirm_msg= Cosa vuoi fare?
 add_confirm_msg= Aggiungi

--- a/locales/ja/addon.properties
+++ b/locales/ja/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= 他にキューに追加された項目はありません
 error_msg= この動画に何か問題が発生しました。また後で試してください。
 error_link= 新しいタブで開く
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= %s を %s から読み込んでいます
+loading_view_msg= $1 を $2 から読み込んでいます
 
 confirm_msg= 何をしたいですか？
 add_confirm_msg= 追加

--- a/locales/kab/addon.properties
+++ b/locales/kab/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= Ulac iferdisen deg udras
 error_msg= Yella wayen ur yeddan ara akken iwata di tvidyut-agi. Ɛreḍ tikelt-nniḍen ticki.
 error_link= Ldi-t deg yiccer amaynut
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= Asal n %s si %s
+loading_view_msg= Asal n $1 si $2
 
 confirm_msg= Acu tebɣiḍ ad ad teggeḍ?
 add_confirm_msg= Rnu

--- a/locales/ms/addon.properties
+++ b/locales/ms/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= Tiada lagi item dalam giliran
 error_msg= Ada sesuatu yang tidak kena dengan video ini. Cuba lagi nanti.
 error_link= Buka dalam tab baru
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= Memuat %s dari %s
+loading_view_msg= Memuat $1 dari $2
 
 confirm_msg= Apa yang anda mahu lakukan?
 add_confirm_msg= Tambah

--- a/locales/nb-NO/addon.properties
+++ b/locales/nb-NO/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= Det er ikke flere objekt i denne køen
 error_msg= Noe har gått galt med denne videoen. Prøv igjen senere.
 error_link= Åpne i ny fane
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= Laster %s fra %s
+loading_view_msg= Laster $1 fra $2
 
 confirm_msg= Hva vil du gjøre?
 add_confirm_msg= Legg til

--- a/locales/nn-NO/addon.properties
+++ b/locales/nn-NO/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= Det finst ingen fleire objekt i køen
 error_msg= Noko gjekk gale med denne videoen. Prøv igjen seinare.
 error_link= Opne i ny fane
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= Lastar %s frå %s
+loading_view_msg= Lastar $1 frå $2
 
 confirm_msg= Kva vil du gjere?
 add_confirm_msg= Legg til

--- a/locales/pt-BR/addon.properties
+++ b/locales/pt-BR/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= Não existem mais itens na fila
 error_msg= Tem algo errado com este vídeo. Tente novamente mais tarde.
 error_link= Abrir em uma nova aba
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= Carregando %s de %s
+loading_view_msg= Carregando $1 de $2
 
 confirm_msg= O que você gostaria de fazer?
 add_confirm_msg= Adicionar

--- a/locales/pt-PT/addon.properties
+++ b/locales/pt-PT/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= Não existem mais itens na fila
 error_msg= Algo correu mal com este vídeo. Tente novamente mais tarde.
 error_link= Abrir em novo separador
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= A carregar %s de %s
+loading_view_msg= A carregar $1 de $2
 
 confirm_msg= O que gostaria de fazer?
 add_confirm_msg= Adicionar

--- a/locales/ru/addon.properties
+++ b/locales/ru/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= Больше нет элементов в очереди
 error_msg= Что-то пошло не так с этим видео. Повторите попытку позже.
 error_link= Открыть в новой вкладке
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= Загрузка %s из %s
+loading_view_msg= Загрузка $1 из $2
 
 confirm_msg= Что вы хотите сделать?
 add_confirm_msg= Добавить

--- a/locales/sk/addon.properties
+++ b/locales/sk/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= V zozname sa nenachádzajú žiadne ďalšie položky
 error_msg= Pri prehrávaní tohto videa nastala chyba. Skúste to neskôr.
 error_link= Otvoriť na novej karte
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= Načítavam %s z %s
+loading_view_msg= Načítavam $1 z $2
 
 confirm_msg= Čo by ste chceli urobiť?
 add_confirm_msg= Pridať do zoznamu

--- a/locales/sl/addon.properties
+++ b/locales/sl/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= V čakalni vrsti ni več predmetov
 error_msg= Prišlo je do napake pri predvajanju videa. Poskusite znova pozneje.
 error_link= Odpri v novem zavihku
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= Nalaganje %s od %s
+loading_view_msg= Nalaganje $1 od $2
 
 confirm_msg= Kaj želite storiti?
 add_confirm_msg= Dodaj

--- a/locales/sq/addon.properties
+++ b/locales/sq/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= S’ka më objekte në radhë
 error_msg= Diç shkoi ters me këtë video. Riprovoni më vonë.
 error_link= Hape në skedë të re
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= Po ngarkohet %s nga %s
+loading_view_msg= Po ngarkohet $1 nga $2
 
 confirm_msg= Ç’do të donit të bënit?
 add_confirm_msg= Shtoje

--- a/locales/sv-SE/addon.properties
+++ b/locales/sv-SE/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= Det finns inga fler objekt i kön
 error_msg= Något har gått fel med denna video. Försök igen senare.
 error_link= Öppna in ny flik
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= Laddar %s från %s
+loading_view_msg= Laddar $1 från $2
 
 confirm_msg= Vad vill du göra?
 add_confirm_msg= Lägg till

--- a/locales/te/addon.properties
+++ b/locales/te/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= క్యూలో ఎటువంటి అంశాలు లే
 error_msg= ఈ వీడియోతో ఎదో తప్పు జరిగినది. మరిలా ప్రయత్నించండి.
 error_link= కొత్త ట్యాబులో తెరువు
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= %s నుండి %s లోడు అవుతున్నది
+loading_view_msg= $1 నుండి $2 లోడు అవుతున్నది
 
 confirm_msg= మీరు ఏమి చేయాలనుకుంటున్నారా?
 add_confirm_msg= జోడించు

--- a/locales/tr/addon.properties
+++ b/locales/tr/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= Kuyrukta başka öğe yok
 error_msg= Bu videoda ters giden bir şeyler var. Daha sonra yeniden deneyin.
 error_link= Yeni sekmede aç
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= %s %s üzerinden yükleniyor
+loading_view_msg= $1 $2 üzerinden yükleniyor
 
 confirm_msg= Ne yapmak istersiniz?
 add_confirm_msg= Ekle

--- a/locales/uk/addon.properties
+++ b/locales/uk/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= Більше немає елементів в черзі
 error_msg= Щось пішло не так з цим відео. Повторіть спробу пізніше.
 error_link= Відкрити у новій вкладці
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= Завантаження %s з %s
+loading_view_msg= Завантаження $1 з $2
 
 confirm_msg= Що ви хочете зробити?
 add_confirm_msg= Додати

--- a/locales/zh-TW/addon.properties
+++ b/locales/zh-TW/addon.properties
@@ -23,7 +23,7 @@ end_of_queue= 播放佇列中沒有更多項目
 error_msg= 這部影片有點怪怪的，請稍候再試著播放。
 error_link= 用新分頁開啟
 # LOCALIZATION NOTE: 1st placeholder is media type, 2nd is domain name
-loading_view_msg= 正在載入 %s 從 %s
+loading_view_msg= 正在載入 $1 從 $2
 
 confirm_msg= 您想要做什麼？
 add_confirm_msg= 新增


### PR DESCRIPTION
Our French localizer noticed that a string was changed (in #957) without a new ID. As a consequence, we have a ton of locales with the wront placeholders.

Tried to fix Persian and Hebrew via Pontoon, since RTL is a pain in Atom.